### PR TITLE
feat(middleware): move route builder options from httputil

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.10.0
 	go.lumeweb.com/gswagger v0.11.0
-	go.lumeweb.com/httputil v0.4.0
+	go.lumeweb.com/httputil v0.4.1
 	go.lumeweb.com/portal v0.4.2-0.20250504192002-4547d95e5a02
 	go.sia.tech/coreutils v0.12.1
 )

--- a/route_builder_options.go
+++ b/route_builder_options.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"github.com/gorilla/mux"
+	"go.lumeweb.com/httputil"
+	"go.lumeweb.com/portal-middleware/auth/jwt"
+	"go.lumeweb.com/portal-middleware/middleware"
+	"go.lumeweb.com/portal/core"
+)
+
+func WithVerification(ctx core.Context) httputil.RouteOption {
+	return func(d *httputil.RouteDefinition) {
+		d.Middlewares = append(d.Middlewares, middleware.AccountVerifiedMiddleware(ctx))
+	}
+}
+
+func With2FA(ctx core.Context) httputil.RouteOption {
+	return func(d *httputil.RouteDefinition) {
+		d.Middlewares = append(d.Middlewares, middleware.AuthMiddleware(ctx, jwt.Purpose2FA))
+	}
+}
+
+// Middleware option
+func WithMiddleware(mw ...mux.MiddlewareFunc) httputil.RouteOption {
+	return func(d *httputil.RouteDefinition) {
+		d.Middlewares = append(d.Middlewares, mw...)
+	}
+}

--- a/route_builder_options_test.go
+++ b/route_builder_options_test.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.lumeweb.com/httputil"
+	"go.lumeweb.com/portal/core"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+	"go.lumeweb.com/portal/core/testing/mocks"
+	"net/http"
+	"testing"
+)
+
+func TestWithVerification(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	ctx := coreTesting.NewTestContext(t)
+
+	// Setup mock expectations
+	mockUser := mocks.NewMockUserService(t)
+	ctx.RegisterService(core.USER_SERVICE, mockUser)
+
+	route := httputil.NewRoute("GET", "/test", handler, WithVerification(ctx))
+
+	assert.Len(t, route.Middlewares, 1)
+	mockUser.AssertExpectations(t)
+}
+
+func TestWith2FA(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	ctx := mocks.NewMockContext(t)
+
+	route := httputil.NewRoute("GET", "/test", handler, With2FA(ctx))
+
+	assert.Len(t, route.Middlewares, 1)
+}
+
+func TestWithMiddleware(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	mw := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	}
+
+	route := httputil.NewRoute("GET", "/test", handler, WithMiddleware(mw))
+
+	assert.Len(t, route.Middlewares, 1)
+}


### PR DESCRIPTION
- Add WithVerification, With2FA and WithMiddleware route options
- Include corresponding test cases for each option
- These were previously located in httputil package