### PR TITLE
refactor: migrate middleware from net/http to echo framework

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	gjwt "github.com/golang-jwt/jwt/v5"
+	mcontext "go.lumeweb.com/portal-middleware/context"
 	"net/http"
 	"strings"
 )
@@ -98,9 +99,6 @@ func FindAuthToken(r *http.Request, secretKey ed25519.PrivateKey, cookieName str
 	return ""
 }
 
-// claimsContextKey is used to store claims in request context
-type ClaimsContextKey struct{}
-
 // claimsWrapper contains both base and custom claims
 type claimsWrapper struct {
 	Base   *gjwt.RegisteredClaims
@@ -114,11 +112,11 @@ func NewClaimsWrapper(base *gjwt.RegisteredClaims, custom gjwt.Claims) *claimsWr
 	}
 }
 
-// GetClaims retrieves claims from context by type
+// GetClaims retrieves claims from echo.Context by type
 func GetClaims[T gjwt.Claims](ctx context.Context) (T, bool) {
 	var zero T
 
-	val := ctx.Value(ClaimsContextKey{})
+	val := ctx.Value(mcontext.ClaimsContextKey)
 	if val == nil {
 		return zero, false
 	}

--- a/auth/middleware/access.go
+++ b/auth/middleware/access.go
@@ -1,33 +1,26 @@
 package middleware
 
 import (
+	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/portal-middleware/auth"
-	"net/http"
-
 	"go.lumeweb.com/portal-middleware/context"
 )
 
-// AccessMiddleware creates HTTP middleware for role-based access control.
+// AccessMiddleware creates Echo middleware for role-based access control.
 // Verifies both user existence and access permissions before allowing request progression.
 // Chain with AuthMiddleware to ensure user context is available.
-// Returns 401 Unauthorized for invalid users, 403 Forbidden for access denials.
-func AccessMiddleware(checker auth.UserChecker, accessChecker auth.AccessChecker) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			deny := func() {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			}
-
-			userID, err := mcontext.GetUserID(r.Context())
+func AccessMiddleware(checker auth.UserChecker, accessChecker auth.AccessChecker) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			r := c.Request()
+			userID, err := mcontext.GetUserID(c)
 			if err != nil {
-				deny()
-				return
+				return echo.ErrUnauthorized
 			}
 
 			exists, err := checker.AccountExists(userID)
 			if err != nil || !exists {
-				deny()
-				return
+				return echo.ErrUnauthorized
 			}
 
 			host := r.Host
@@ -36,15 +29,13 @@ func AccessMiddleware(checker auth.UserChecker, accessChecker auth.AccessChecker
 			}
 			ok, err := accessChecker.CheckAccess(userID, host, r.URL.Path, r.Method)
 			if err != nil {
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-				return
+				return echo.ErrInternalServerError
 			}
 			if !ok {
-				deny()
-				return
+				return echo.ErrUnauthorized
 			}
 
-			next.ServeHTTP(w, r)
-		})
+			return next(c)
+		}
 	}
 }

--- a/auth/middleware/access_test.go
+++ b/auth/middleware/access_test.go
@@ -2,6 +2,8 @@ package middleware
 
 import (
 	"context"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal-middleware/auth"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +14,7 @@ import (
 	coreMocks "go.lumeweb.com/portal/core/testing/mocks"
 )
 
-func setupAccessTest(t *testing.T) (*auth.MockUserChecker, *coreMocks.MockAccessService, func(http.Handler) http.Handler) {
+func setupAccessTest(t *testing.T) (*auth.MockUserChecker, *coreMocks.MockAccessService, echo.MiddlewareFunc) {
 	mockUserChecker := auth.NewMockUserChecker(t)
 	mockAccessChecker := coreMocks.NewMockAccessService(t)
 	middleware := AccessMiddleware(mockUserChecker, mockAccessChecker)
@@ -31,7 +33,14 @@ func TestAccessMiddleware(t *testing.T) {
 		req = req.WithContext(context.WithValue(req.Context(), mcontext.UserIDKey, uint(1)))
 		w := httptest.NewRecorder()
 
-		middleware(testHandler).ServeHTTP(w, req)
+		e := echo.New()
+		c := e.NewContext(req, w)
+		c.Set(string(mcontext.UserIDKey), uint(1))
+
+		err := middleware(func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})(c)
+		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
 
@@ -45,8 +54,14 @@ func TestAccessMiddleware(t *testing.T) {
 		req = req.WithContext(context.WithValue(req.Context(), mcontext.UserIDKey, uint(2)))
 		w := httptest.NewRecorder()
 
-		middleware(testHandler).ServeHTTP(w, req)
-		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		e := echo.New()
+		c := e.NewContext(req, w)
+		c.Set(string(mcontext.UserIDKey), uint(2))
+
+		err := middleware(func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})(c)
+		assert.Equal(t, echo.ErrUnauthorized, err)
 	})
 
 	t.Run("user not found", func(t *testing.T) {
@@ -58,8 +73,14 @@ func TestAccessMiddleware(t *testing.T) {
 		req = req.WithContext(context.WithValue(req.Context(), mcontext.UserIDKey, uint(3)))
 		w := httptest.NewRecorder()
 
-		middleware(testHandler).ServeHTTP(w, req)
-		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		e := echo.New()
+		c := e.NewContext(req, w)
+		c.Set(string(mcontext.UserIDKey), uint(3))
+
+		err := middleware(func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})(c)
+		assert.Equal(t, echo.ErrUnauthorized, err)
 	})
 
 	t.Run("access check error", func(t *testing.T) {
@@ -72,7 +93,13 @@ func TestAccessMiddleware(t *testing.T) {
 		req = req.WithContext(context.WithValue(req.Context(), mcontext.UserIDKey, uint(4)))
 		w := httptest.NewRecorder()
 
-		middleware(testHandler).ServeHTTP(w, req)
-		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		e := echo.New()
+		c := e.NewContext(req, w)
+		c.Set(string(mcontext.UserIDKey), uint(4))
+
+		err := middleware(func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})(c)
+		assert.Equal(t, echo.ErrInternalServerError, err)
 	})
 }

--- a/auth/middleware/account.go
+++ b/auth/middleware/account.go
@@ -1,37 +1,32 @@
 package middleware
 
 import (
+	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/portal-middleware/auth"
-	"net/http"
-
 	"go.lumeweb.com/portal-middleware/context"
 )
 
-// AccountVerified creates HTTP middleware that requires verified user accounts.
+// AccountVerified creates Echo middleware that requires verified user accounts.
 // Checks the verification status of the user in the request context.
-// Returns 403 Forbidden if account is not verified, 500 for verification errors.
 // Must be used after AuthMiddleware to ensure user context exists.
-func AccountVerified(checker auth.UserChecker) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			userID, err := mcontext.GetUserID(r.Context())
+func AccountVerified(checker auth.UserChecker) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			userID, err := mcontext.GetUserID(c)
 			if err != nil {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
+				return echo.ErrUnauthorized
 			}
 
 			verified, err := checker.IsAccountVerified(userID)
 			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
+				return echo.ErrInternalServerError
 			}
 
 			if !verified {
-				http.Error(w, "Account not verified", http.StatusForbidden)
-				return
+				return echo.ErrForbidden
 			}
 
-			next.ServeHTTP(w, r)
-		})
+			return next(c)
+		}
 	}
 }

--- a/auth/middleware/account_test.go
+++ b/auth/middleware/account_test.go
@@ -2,6 +2,8 @@ package middleware
 
 import (
 	"context"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal-middleware/auth"
 	"net/http"
 	"net/http/httptest"
@@ -22,37 +24,56 @@ func TestAccountVerifiedMiddleware(t *testing.T) {
 		req = req.WithContext(context.WithValue(req.Context(), mcontext.UserIDKey, uint(1)))
 		w := httptest.NewRecorder()
 
-		middleware(testHandler).ServeHTTP(w, req)
+		e := echo.New()
+		c := e.NewContext(req, w)
+		c.Set(string(mcontext.UserIDKey), uint(1))
+
+		err := middleware(func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})(c)
+		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
 
 	t.Run("unverified user", func(t *testing.T) {
 		mockChecker.On("IsAccountVerified", uint(2)).Return(false, nil)
 
+		e := echo.New()
 		req := httptest.NewRequest("GET", "/", nil)
-		req = req.WithContext(context.WithValue(req.Context(), mcontext.UserIDKey, uint(2)))
-		w := httptest.NewRecorder()
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.Set(string(mcontext.UserIDKey), uint(2))
 
-		middleware(testHandler).ServeHTTP(w, req)
-		assert.Equal(t, http.StatusForbidden, w.Code)
+		err := middleware(func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})(c)
+		assert.Equal(t, echo.ErrForbidden, err)
 	})
 
 	t.Run("no user in context", func(t *testing.T) {
+		e := echo.New()
 		req := httptest.NewRequest("GET", "/", nil)
-		w := httptest.NewRecorder()
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
 
-		middleware(testHandler).ServeHTTP(w, req)
-		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		err := middleware(func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})(c)
+		assert.Equal(t, echo.ErrUnauthorized, err)
 	})
 
 	t.Run("service error", func(t *testing.T) {
 		mockChecker.On("IsAccountVerified", uint(3)).Return(false, assert.AnError)
 
+		e := echo.New()
 		req := httptest.NewRequest("GET", "/", nil)
-		req = req.WithContext(context.WithValue(req.Context(), mcontext.UserIDKey, uint(3)))
-		w := httptest.NewRecorder()
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.Set(string(mcontext.UserIDKey), uint(3))
 
-		middleware(testHandler).ServeHTTP(w, req)
-		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		err := middleware(func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})(c)
+		assert.Equal(t, echo.ErrInternalServerError, err)
 	})
 }

--- a/auth/middleware/adapter.go
+++ b/auth/middleware/adapter.go
@@ -1,13 +1,13 @@
 package middleware
 
 import (
+	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/portal-middleware/auth/adapter"
 	"go.lumeweb.com/portal/core"
-	"net/http"
 )
 
 // NewAccessMiddlewareFromCore creates an AccessMiddleware using services from core.Context
-func NewAccessMiddlewareFromCore(ctx core.Context) func(http.Handler) http.Handler {
+func NewAccessMiddlewareFromCore(ctx core.Context) echo.MiddlewareFunc {
 	userChecker := adapter.NewUserCheckerFromCore(ctx)
 	accessChecker := adapter.NewAccessCheckerFromCore(ctx)
 	return AccessMiddleware(userChecker, accessChecker)

--- a/auth/middleware/adapter_test.go
+++ b/auth/middleware/adapter_test.go
@@ -1,7 +1,7 @@
 package middleware
 
 import (
-	"context"
+	echo "github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	mo "go.lumeweb.com/portal-middleware/context"
@@ -80,20 +80,29 @@ func TestNewAccessMiddlewareFromCore(t *testing.T) {
 			middleware := NewAccessMiddlewareFromCore(ctx)
 			require.NotNil(t, middleware)
 
-			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			})
-			handler := middleware(testHandler)
-
+			e := echo.New()
 			req := httptest.NewRequest("GET", "http://example.com/api", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
 			if tc.userID != 0 {
-				req = req.WithContext(context.WithValue(req.Context(), mo.UserIDKey, tc.userID))
+				c.Set(string(mo.UserIDKey), tc.userID)
 			}
 
-			w := httptest.NewRecorder()
-			handler.ServeHTTP(w, req)
+			handler := middleware(func(c echo.Context) error {
+				return c.NoContent(http.StatusOK)
+			})
 
-			assert.Equal(t, tc.expectedStatus, w.Code)
+			err := handler(c)
+			if tc.expectedStatus != http.StatusOK {
+				require.Error(t, err)
+				httpErr, ok := err.(*echo.HTTPError)
+				require.True(t, ok)
+				assert.Equal(t, tc.expectedStatus, httpErr.Code)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedStatus, rec.Code)
+			}
 			mockUserSvc.AssertExpectations(t)
 			mockAccessSvc.AssertExpectations(t)
 		})

--- a/auth/middleware/auth.go
+++ b/auth/middleware/auth.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	gjwt "github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/portal-middleware/auth"
 	"go.lumeweb.com/portal-middleware/auth/adapter"
 	"go.lumeweb.com/portal-middleware/auth/jwt"
 	"go.lumeweb.com/portal-middleware/auth/validation"
 	mcontext "go.lumeweb.com/portal-middleware/context"
-	"net/http"
 	"reflect"
 	"strconv"
 )
@@ -31,10 +31,9 @@ type AuthMiddlewareOptions struct {
 	ExpectedClaims gjwt.Claims
 }
 
-// AuthMiddleware creates HTTP middleware for JWT authentication
+// AuthMiddleware creates Echo middleware for JWT authentication
 // Validates tokens and injects user context if valid
-// Returns a handler that can be chained with other middleware
-func AuthMiddleware(options AuthMiddlewareOptions) func(http.Handler) http.Handler {
+func AuthMiddleware(options AuthMiddlewareOptions) echo.MiddlewareFunc {
 	if options.Config == nil {
 		panic("AuthMiddleware requires a ConfigProvider")
 	}
@@ -42,16 +41,15 @@ func AuthMiddleware(options AuthMiddlewareOptions) func(http.Handler) http.Handl
 		panic("AuthMiddleware requires a Purpose")
 	}
 
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			r := c.Request()
 			authToken := auth.FindAuthToken(r, options.Config.GetPrivateKey(), options.Config.GetAuthCookieName(), options.Config.GetAuthTokenName())
 			if authToken == "" {
 				if !options.EmptyAllowed {
-					http.Error(w, "Missing token", http.StatusUnauthorized)
-					return
+					return echo.ErrUnauthorized
 				}
-				next.ServeHTTP(w, r)
-				return
+				return next(c)
 			}
 
 			validator := options.Validator
@@ -71,21 +69,31 @@ func AuthMiddleware(options AuthMiddlewareOptions) func(http.Handler) http.Handl
 				if options.ExpiredAllowed && errors.Is(err, gjwt.ErrTokenExpired) {
 					// We still need baseClaims to proceed
 					if baseClaims == nil {
-						http.Error(w, "Invalid token", http.StatusUnauthorized)
-						return
+						return echo.ErrUnauthorized
 					}
 				} else {
-					http.Error(w, "Invalid token", http.StatusUnauthorized)
-					return
+					return echo.ErrUnauthorized
 				}
 			}
 
+			// If validation passed but we got nil claims, reject
+			if baseClaims == nil {
+				return echo.ErrUnauthorized
+			}
+
+			// If we got claims but they don't match expected type, reject
+			if customClaims != nil && !reflect.TypeOf(customClaims).AssignableTo(reflect.TypeOf(claimsType)) {
+				return echo.ErrUnauthorized
+			}
+
 			// Build context with all claims
-			ctx := r.Context()
 			if baseClaims != nil {
-				userID, _ := strconv.ParseUint(baseClaims.Subject, 10, 64)
-				ctx = context.WithValue(ctx, mcontext.UserIDKey, uint(userID))
-				ctx = context.WithValue(ctx, mcontext.AuthTokenKey, authToken)
+				userID, err := strconv.ParseUint(baseClaims.Subject, 10, 64)
+				if err != nil {
+					return echo.ErrUnauthorized
+				}
+				c.Set(string(mcontext.UserIDKey), uint(userID))
+				c.Set(string(mcontext.AuthTokenKey), authToken)
 
 				// Only store custom claims if they match the expected type
 				if customClaims != nil {
@@ -99,23 +107,31 @@ func AuthMiddleware(options AuthMiddlewareOptions) func(http.Handler) http.Handl
 						// Check if types match directly or via pointer
 						if !actualType.AssignableTo(expectedClaimsType) &&
 							!actualType.AssignableTo(expectedPtrType) {
-							http.Error(w, "Invalid token claims", http.StatusUnauthorized)
-							return
+							return echo.ErrUnauthorized
 						}
 					}
 					// Store claims in context
 					wrapper := auth.NewClaimsWrapper(baseClaims, customClaims)
-					ctx = context.WithValue(ctx, auth.ClaimsContextKey{}, wrapper)
+					c.Set(string(mcontext.ClaimsContextKey), wrapper)
+
+					// Also set in request context for compatibility
+					req := c.Request()
+					ctx := context.WithValue(req.Context(), mcontext.ClaimsContextKey, wrapper)
+					c.SetRequest(req.WithContext(ctx))
 				} else {
 					// Store just base claims if no custom claims
 					wrapper := auth.NewClaimsWrapper(baseClaims, nil)
-					ctx = context.WithValue(ctx, auth.ClaimsContextKey{}, wrapper)
+					c.Set(string(mcontext.ClaimsContextKey), wrapper)
+
+					// Also set in request context for compatibility
+					req := c.Request()
+					ctx := context.WithValue(req.Context(), mcontext.ClaimsContextKey, wrapper)
+					c.SetRequest(req.WithContext(ctx))
 				}
 			}
 
-			r = r.WithContext(ctx)
-			next.ServeHTTP(w, r)
-		})
+			return next(c)
+		}
 	}
 }
 

--- a/auth/middleware/auth_test.go
+++ b/auth/middleware/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"errors"
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal-middleware/auth"
 	"go.lumeweb.com/portal-middleware/auth/adapter"
@@ -58,27 +59,27 @@ func TestAuthMiddleware(t *testing.T) {
 		req := httptest.NewRequest("GET", "/", nil)
 		req.Header.Set("Authorization", "Bearer valid.token")
 
-		// Custom handler to verify context values
 		handlerCalled := false
-		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		e := echo.New()
+		c := e.NewContext(req, rr)
+		err := middleware(func(c echo.Context) error {
 			handlerCalled = true
 
 			// Verify user ID was set in context
-			userID, err := mcontext.GetUserID(r.Context())
-			assert.NoError(t, err)
+			// Verify user ID was set in context
+			userID, err := mcontext.GetUserID(c)
+			require.NoError(t, err)
 			assert.Equal(t, uint(123), userID)
 
 			// Verify auth token was set in context
-			authToken, err := mcontext.GetAuthToken(r.Context())
-			assert.NoError(t, err)
+			authToken, err := mcontext.GetAuthToken(c)
+			require.NoError(t, err)
 			assert.Equal(t, "valid.token", authToken)
 
-			w.WriteHeader(http.StatusOK)
-		})
-
-		handler := middleware(testHandler)
-		handler.ServeHTTP(rr, req)
-
+			return c.NoContent(http.StatusOK)
+		})(c)
+		require.NoError(t, err)
 		assert.True(t, handlerCalled)
 		assert.Equal(t, http.StatusOK, rr.Code)
 		mockConfig.AssertExpectations(t)
@@ -100,10 +101,16 @@ func TestAuthMiddleware(t *testing.T) {
 		})
 
 		rr := httptest.NewRecorder()
-		handler := middleware(testHandler)
-		handler.ServeHTTP(rr, req)
+		e := echo.New()
+		c := e.NewContext(req, rr)
+		err := middleware(func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})(c)
 
-		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+		assert.Error(t, err)
+		httpErr, ok := err.(*echo.HTTPError)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 	})
 
 	t.Run("expired but allowed", func(t *testing.T) {
@@ -123,9 +130,12 @@ func TestAuthMiddleware(t *testing.T) {
 		})
 
 		rr := httptest.NewRecorder()
-		handler := middleware(testHandler)
-		handler.ServeHTTP(rr, req)
-
+		e := echo.New()
+		c := e.NewContext(req, rr)
+		err := middleware(func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})(c)
+		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rr.Code)
 	})
 
@@ -144,10 +154,15 @@ func TestAuthMiddleware(t *testing.T) {
 		})
 
 		rr := httptest.NewRecorder()
-		handler := middleware(testHandler)
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+		e := echo.New()
+		c := e.NewContext(req, rr)
+		err := middleware(func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})(c)
+		assert.Error(t, err)
+		httpErr, ok := err.(*echo.HTTPError)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 	})
 
 	t.Run("custom claims registration", func(t *testing.T) {
@@ -184,14 +199,16 @@ func TestAuthMiddleware(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer valid.token")
 
 		rr := httptest.NewRecorder()
-		customHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			claims, ok := auth.GetClaims[*CustomClaims](r.Context())
-			assert.True(t, ok, "should retrieve custom claims")
+		e := echo.New()
+		c := e.NewContext(req, rr)
+		err := middleware(func(c echo.Context) error {
+			claims, ok := auth.GetClaims[*CustomClaims](c.Request().Context())
+			require.True(t, ok, "should retrieve custom claims")
+			require.NotNil(t, claims, "claims should not be nil")
 			assert.Equal(t, "test_value", claims.CustomField)
-			w.WriteHeader(http.StatusOK)
-		})
-		handler := middleware(customHandler)
-		handler.ServeHTTP(rr, req)
+			return c.NoContent(http.StatusOK)
+		})(c)
+		assert.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
 		mockValidator.AssertExpectations(t)
@@ -260,15 +277,30 @@ func TestAuthMiddleware_DefaultRegisteredClaims(t *testing.T) {
 		})
 
 		rr := httptest.NewRecorder()
-		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Should be able to get base claims
-			claims, ok := auth.GetClaims[*gjwt.RegisteredClaims](r.Context())
+		e := echo.New()
+		c := e.NewContext(req, rr)
+		err = middleware(func(c echo.Context) error {
+			// Verify user ID was set in context
+			userID, err := mcontext.GetUserID(c)
+			require.NoError(t, err)
+			assert.Equal(t, uint(123), userID)
+
+			// Verify auth token was set in context
+			authToken, err := mcontext.GetAuthToken(c)
+			require.NoError(t, err)
+			assert.Equal(t, validToken, authToken)
+
+			// Verify claims wrapper exists
+			claimsWrapper := c.Request().Context().Value(mcontext.ClaimsContextKey)
+			require.NotNil(t, claimsWrapper)
+			
+			// Get base claims
+			claims, ok := auth.GetClaims[*gjwt.RegisteredClaims](c.Request().Context())
 			assert.True(t, ok)
 			assert.Equal(t, "123", claims.Subject)
-			w.WriteHeader(http.StatusOK)
-		}))
-		handler.ServeHTTP(rr, req)
-
+			return c.NoContent(http.StatusOK)
+		})(c)
+		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rr.Code)
 		mockValidator.AssertExpectations(t)
 	})
@@ -300,18 +332,20 @@ func TestAuthMiddleware_DefaultRegisteredClaims(t *testing.T) {
 		})
 
 		rr := httptest.NewRecorder()
-		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		e := echo.New()
+		c := e.NewContext(req, rr)
+		err = middleware(func(c echo.Context) error {
 			// Should only get base claims
-			claims, ok := auth.GetClaims[*gjwt.RegisteredClaims](r.Context())
+			claims, ok := auth.GetClaims[*gjwt.RegisteredClaims](c.Request().Context())
 			assert.True(t, ok)
 			assert.Equal(t, "123", claims.Subject)
 
 			// Should not get custom claims
-			_, ok = auth.GetClaims[*CustomClaims](r.Context())
+			_, ok = auth.GetClaims[*CustomClaims](c.Request().Context())
 			assert.False(t, ok)
-			w.WriteHeader(http.StatusOK)
-		}))
-		handler.ServeHTTP(rr, req)
+			return c.NoContent(http.StatusOK)
+		})(c)
+		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
 		mockValidator.AssertExpectations(t)
@@ -371,14 +405,15 @@ func TestAuthMiddleware_CustomClaims(t *testing.T) {
 		})
 
 		rr := httptest.NewRecorder()
-		customHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			claims, ok := auth.GetClaims[*CustomClaims](r.Context())
+		e := echo.New()
+		c := e.NewContext(req, rr)
+		err = middleware(func(c echo.Context) error {
+			claims, ok := auth.GetClaims[*CustomClaims](c.Request().Context())
 			assert.True(t, ok)
 			assert.Equal(t, "admin", claims.Role)
-			w.WriteHeader(http.StatusOK)
-		})
-		handler := middleware(customHandler)
-		handler.ServeHTTP(rr, req)
+			return c.NoContent(http.StatusOK)
+		})(c)
+		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
 		mockValidator.AssertExpectations(t)
@@ -413,13 +448,14 @@ func TestAuthMiddleware_CustomClaims(t *testing.T) {
 		})
 
 		rr := httptest.NewRecorder()
-		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		e := echo.New()
+		c := e.NewContext(req, rr)
+		err = middleware(func(c echo.Context) error {
 			t.Error("Handler should not be called for invalid claim types")
-		}))
+			return c.NoContent(http.StatusOK)
+		})(c)
 
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+		assert.Equal(t, echo.ErrUnauthorized, err)
 		mockValidator.AssertExpectations(t)
 	})
 }
@@ -460,10 +496,15 @@ func TestAuthMiddleware_ValidationErrors(t *testing.T) {
 			ExpectedClaims: &CustomClaims{},
 		})
 
-		rr := httptest.NewRecorder()
-		handler := middleware(testHandler)
-		handler.ServeHTTP(rr, req)
+		e := echo.New()
+		e.Use(middleware)
+		e.GET("/", func(c echo.Context) error {
+			t.Error("Handler should not be reached for invalid token")
+			return c.NoContent(http.StatusOK)
+		})
 
+		rr := httptest.NewRecorder()
+		e.ServeHTTP(rr, req)
 		assert.Equal(t, http.StatusUnauthorized, rr.Code)
 	})
 
@@ -483,10 +524,15 @@ func TestAuthMiddleware_ValidationErrors(t *testing.T) {
 			ExpectedClaims: &CustomClaims{},
 		})
 
-		rr := httptest.NewRecorder()
-		handler := middleware(testHandler)
-		handler.ServeHTTP(rr, req)
+		e := echo.New()
+		e.Use(middleware)
+		e.GET("/", func(c echo.Context) error {
+			t.Error("Handler should not be reached for malformed claims")
+			return c.NoContent(http.StatusOK)
+		})
 
+		rr := httptest.NewRecorder()
+		e.ServeHTTP(rr, req)
 		assert.Equal(t, http.StatusUnauthorized, rr.Code)
 	})
 }
@@ -502,7 +548,7 @@ func TestClaimsContext(t *testing.T) {
 	customClaims := &CustomClaims{FeatureFlag: true}
 
 	// Store claims
-	ctx = context.WithValue(ctx, auth.ClaimsContextKey{}, auth.NewClaimsWrapper(baseClaims, customClaims))
+	ctx = context.WithValue(ctx, mcontext.ClaimsContextKey, auth.NewClaimsWrapper(baseClaims, customClaims))
 
 	t.Run("get custom claims", func(t *testing.T) {
 		claims, ok := auth.GetClaims[*CustomClaims](ctx)

--- a/auth/middleware/shared_test.go
+++ b/auth/middleware/shared_test.go
@@ -1,7 +1,0 @@
-package middleware
-
-import "net/http"
-
-var testHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
-})

--- a/context/context.go
+++ b/context/context.go
@@ -7,8 +7,8 @@
 package mcontext
 
 import (
-	"context"
 	"errors"
+	"github.com/labstack/echo/v4"
 )
 
 // Key represents a type-safe context key for storing request-scoped values.
@@ -18,46 +18,49 @@ type Key string
 const (
 	// UserIDKey is the context key for storing authenticated user IDs (uint type).
 	// Use with context.WithValue and GetUserID for type-safe access.
-	UserIDKey    Key = "userID"
-	
+	UserIDKey Key = "userID"
+
 	// AuthTokenKey is the context key for storing validated authentication tokens.
 	// Use with context.WithValue and GetAuthToken for type-safe access.
 	AuthTokenKey Key = "authToken"
+
+	// ClaimsContextKey is the context key for storing JWT claims
+	ClaimsContextKey Key = "jwtClaims"
 )
 
 var (
-	// ErrUserContextInvalid occurs when a context value exists for UserIDKey 
+	// ErrUserContextInvalid occurs when a context value exists for UserIDKey
 	// but is not of type uint. Typically indicates improper context population.
-	ErrUserContextInvalid      = errors.New("user id stored in context is not of type uint")
-	
+	ErrUserContextInvalid = errors.New("user id stored in context is not of type uint")
+
 	// ErrAuthTokenContextInvalid occurs when a context value exists for AuthTokenKey
 	// but is not of type string. Indicates invalid token storage.
 	ErrAuthTokenContextInvalid = errors.New("auth token stored in context is not of type string")
 )
 
-// GetUserID retrieves a user ID from the request context. Validates that:
+// GetUserID retrieves a user ID from the echo context. Validates that:
 // 1. A value exists for UserIDKey
 // 2. The value is of type uint
 //
 // Returns:
 //   - uint: The authenticated user ID
 //   - error: ErrUserContextInvalid if value is missing or invalid type
-func GetUserID(ctx context.Context) (uint, error) {
-	userID, ok := ctx.Value(UserIDKey).(uint)
+func GetUserID(c echo.Context) (uint, error) {
+	userID, ok := c.Get(string(UserIDKey)).(uint)
 	if !ok {
 		return 0, ErrUserContextInvalid
 	}
 	return userID, nil
 }
 
-// GetAuthToken retrieves an authentication token from the request context.
+// GetAuthToken retrieves an authentication token from the echo context.
 // Validates that any existing AuthTokenKey value is a string.
 //
 // Returns:
 //   - string: The raw authentication token
 //   - error: ErrAuthTokenContextInvalid if type assertion fails
-func GetAuthToken(ctx context.Context) (string, error) {
-	authToken, ok := ctx.Value(AuthTokenKey).(string)
+func GetAuthToken(c echo.Context) (string, error) {
+	authToken, ok := c.Get(string(AuthTokenKey)).(string)
 	if !ok {
 		return "", ErrAuthTokenContextInvalid
 	}

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -1,49 +1,67 @@
 package mcontext
 
 import (
-	"context"
 	"testing"
-	
+
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetUserID(t *testing.T) {
-	t.Run("valid user ID in context", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), UserIDKey, uint(123))
-		userID, err := GetUserID(ctx)
+	t.Run("valid user ID in echo context", func(t *testing.T) {
+		e := echo.New()
+		c := e.NewContext(nil, nil)
+		c.Set(string(UserIDKey), uint(123))
+
+		userID, err := GetUserID(c)
 		require.NoError(t, err)
 		assert.Equal(t, uint(123), userID)
 	})
 
 	t.Run("invalid user ID type", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), UserIDKey, "invalid")
-		_, err := GetUserID(ctx)
+		e := echo.New()
+		c := e.NewContext(nil, nil)
+		c.Set(string(UserIDKey), "invalid")
+
+		_, err := GetUserID(c)
 		assert.ErrorIs(t, err, ErrUserContextInvalid)
 	})
 
 	t.Run("no user ID in context", func(t *testing.T) {
-		_, err := GetUserID(context.Background())
+		e := echo.New()
+		c := e.NewContext(nil, nil)
+
+		_, err := GetUserID(c)
 		assert.ErrorIs(t, err, ErrUserContextInvalid)
 	})
 }
 
 func TestGetAuthToken(t *testing.T) {
-	t.Run("valid auth token in context", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), AuthTokenKey, "test-token")
-		token, err := GetAuthToken(ctx)
+	t.Run("valid auth token in echo context", func(t *testing.T) {
+		e := echo.New()
+		c := e.NewContext(nil, nil)
+		c.Set(string(AuthTokenKey), "test-token")
+
+		token, err := GetAuthToken(c)
 		require.NoError(t, err)
 		assert.Equal(t, "test-token", token)
 	})
 
 	t.Run("invalid auth token type", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), AuthTokenKey, 123)
-		_, err := GetAuthToken(ctx)
+		e := echo.New()
+		c := e.NewContext(nil, nil)
+		c.Set(string(AuthTokenKey), 123)
+
+		_, err := GetAuthToken(c)
 		assert.ErrorIs(t, err, ErrAuthTokenContextInvalid)
 	})
 
 	t.Run("no auth token in context", func(t *testing.T) {
-		_, err := GetAuthToken(context.Background())
+		e := echo.New()
+		c := e.NewContext(nil, nil)
+
+		_, err := GetAuthToken(c)
 		assert.ErrorIs(t, err, ErrAuthTokenContextInvalid)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,15 @@ require (
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/gorilla/mux v1.8.2-0.20240619235004-db9d1d0073d2
+	github.com/labstack/echo/v4 v4.13.4
 	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.10.0
-	go.lumeweb.com/gswagger v0.11.0
+	go.lumeweb.com/gswagger v0.15.0
 	go.lumeweb.com/httputil v0.4.1
 	go.lumeweb.com/portal v0.4.2-0.20250504192002-4547d95e5a02
+	go.lumeweb.com/portal-router v0.1.8
 	go.sia.tech/coreutils v0.12.1
+	gorm.io/gorm v1.25.12
 )
 
 require (
@@ -65,7 +68,10 @@ require (
 	github.com/klauspost/reedsolomon v1.12.4 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect
 	github.com/knadh/koanf/v2 v2.1.2 // indirect
+	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
@@ -85,6 +91,8 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/urfave/cli/v3 v3.0.0-beta1 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.19 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.19 // indirect
@@ -95,11 +103,11 @@ require (
 	go.sia.tech/renterd v1.1.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/crypto v0.36.0 // indirect
+	golang.org/x/crypto v0.38.0 // indirect
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
-	golang.org/x/net v0.37.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
-	golang.org/x/text v0.23.0 // indirect
+	golang.org/x/net v0.40.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/text v0.25.0 // indirect
 	golang.org/x/tools v0.31.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
@@ -109,7 +117,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/datatypes v1.2.5 // indirect
 	gorm.io/driver/mysql v1.5.7 // indirect
-	gorm.io/gorm v1.25.12 // indirect
 	lukechampine.com/blake3 v1.4.0 // indirect
 	lukechampine.com/frand v1.5.1 // indirect
 )

--- a/middleware/access.go
+++ b/middleware/access.go
@@ -1,15 +1,14 @@
 package middleware
 
 import (
-	"go.lumeweb.com/portal-middleware/auth/middleware"
-	"net/http"
-
+	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/portal-middleware/auth/adapter"
+	"go.lumeweb.com/portal-middleware/auth/middleware"
 	"go.lumeweb.com/portal/core"
 )
 
 // AccessMiddleware creates middleware for checking access permissions using core services
-func AccessMiddleware(ctx core.Context) func(http.Handler) http.Handler {
+func AccessMiddleware(ctx core.Context) echo.MiddlewareFunc {
 	userChecker := adapter.NewUserCheckerFromCore(ctx)
 	accessChecker := adapter.NewAccessCheckerFromCore(ctx)
 

--- a/middleware/access_test.go
+++ b/middleware/access_test.go
@@ -1,8 +1,8 @@
 package middleware
 
 import (
-	"context"
 	"errors"
+	"github.com/labstack/echo/v4"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,40 +20,43 @@ import (
 func testAccessMiddlewareHelper(t *testing.T, tests []struct {
 	name                    string
 	setupContext            func() core.Context
-	customMiddlewareFactory func(core.Context) func(http.Handler) http.Handler // Add this field
+	customMiddlewareFactory func(core.Context) echo.MiddlewareFunc // Updated to echo.MiddlewareFunc
 	userID                  uint
 	path                    string
 	expectedStatus          int
-}, createMiddleware func(core.Context) func(http.Handler) http.Handler) {
+}, createMiddleware func(core.Context) echo.MiddlewareFunc) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			coreCtx := tt.setupContext()
-			var ms func(http.Handler) http.Handler
+			var ms echo.MiddlewareFunc
 
 			// Check if a custom middleware factory is provided in the test case
 			if tt.customMiddlewareFactory != nil {
 				ms = tt.customMiddlewareFactory(coreCtx)
 			} else {
-				// This branch is likely not needed anymore if all tests use custom factories
-				// but keeping it for completeness if you have other tests using the default.
 				ms = createMiddleware(coreCtx)
 			}
 
-			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
+			e := echo.New()
+			e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+				return func(c echo.Context) error {
+					if tt.userID > 0 {
+						c.Set(string(mo.UserIDKey), tt.userID)
+					}
+					return next(c)
+				}
 			})
-			handler := ms(testHandler)
+			e.Use(ms)
+			e.GET(tt.path, func(c echo.Context) error {
+				return c.NoContent(http.StatusOK)
+			})
 
 			req := httptest.NewRequest("GET", tt.path, nil)
-			if tt.userID > 0 {
-				reqCtx := context.WithValue(req.Context(), mo.UserIDKey, tt.userID)
-				req = req.WithContext(reqCtx)
-			}
 			req.Host = "example.com"
-
-			w := httptest.NewRecorder()
-			handler.ServeHTTP(w, req)
-			assert.Equal(t, tt.expectedStatus, w.Code, "Expected status code %d, got %d", tt.expectedStatus, w.Code)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+			
+			assert.Equal(t, tt.expectedStatus, rec.Code, "Expected status code %d, got %d", tt.expectedStatus, rec.Code)
 		})
 	}
 }
@@ -62,7 +65,7 @@ func TestAccessMiddleware(t *testing.T) {
 	tests := []struct {
 		name                    string
 		setupContext            func() core.Context
-		customMiddlewareFactory func(core.Context) func(http.Handler) http.Handler // Add this field
+		customMiddlewareFactory func(core.Context) echo.MiddlewareFunc
 		userID                  uint
 		path                    string
 		expectedStatus          int
@@ -74,7 +77,7 @@ func TestAccessMiddleware(t *testing.T) {
 				// because we will mock the adapter interfaces directly.
 				return coreTesting.NewTestContext(t)
 			},
-			customMiddlewareFactory: func(coreCtx core.Context) func(http.Handler) http.Handler {
+			customMiddlewareFactory: func(coreCtx core.Context) echo.MiddlewareFunc {
 				// Create mocks for the interfaces the middleware directly uses
 				mockUserChecker := auth.NewMockUserChecker(t)     // Use auth.NewMockUserChecker
 				mockAccessChecker := auth.NewMockAccessChecker(t) // Use auth.NewMockAccessChecker
@@ -85,7 +88,7 @@ func TestAccessMiddleware(t *testing.T) {
 					Return(true, nil).Once()
 
 				// Instantiate the middleware with the mocked interfaces
-				return authMiddleware.AccessMiddleware(mockUserChecker, mockAccessChecker) // Use authMiddleware
+				return authMiddleware.AccessMiddleware(mockUserChecker, mockAccessChecker)
 			},
 			userID:         1,
 			path:           "/allowed",
@@ -96,7 +99,7 @@ func TestAccessMiddleware(t *testing.T) {
 			setupContext: func() core.Context {
 				return coreTesting.NewTestContext(t)
 			},
-			customMiddlewareFactory: func(coreCtx core.Context) func(http.Handler) http.Handler {
+			customMiddlewareFactory: func(coreCtx core.Context) echo.MiddlewareFunc {
 				mockUserChecker := auth.NewMockUserChecker(t)
 				mockAccessChecker := auth.NewMockAccessChecker(t)
 
@@ -115,7 +118,7 @@ func TestAccessMiddleware(t *testing.T) {
 			setupContext: func() core.Context {
 				return coreTesting.NewTestContext(t)
 			},
-			customMiddlewareFactory: func(coreCtx core.Context) func(http.Handler) http.Handler {
+			customMiddlewareFactory: func(coreCtx core.Context) echo.MiddlewareFunc {
 				mockUserChecker := auth.NewMockUserChecker(t)
 				mockAccessChecker := auth.NewMockAccessChecker(t)
 
@@ -134,7 +137,7 @@ func TestAccessMiddleware(t *testing.T) {
 			setupContext: func() core.Context {
 				return coreTesting.NewTestContext(t)
 			},
-			customMiddlewareFactory: func(coreCtx core.Context) func(http.Handler) http.Handler {
+			customMiddlewareFactory: func(coreCtx core.Context) echo.MiddlewareFunc {
 				mockUserChecker := auth.NewMockUserChecker(t)
 				mockAccessChecker := auth.NewMockAccessChecker(t)
 
@@ -153,11 +156,10 @@ func TestAccessMiddleware(t *testing.T) {
 			setupContext: func() core.Context {
 				return coreTesting.NewTestContext(t)
 			},
-			customMiddlewareFactory: func(coreCtx core.Context) func(http.Handler) http.Handler {
+			customMiddlewareFactory: func(coreCtx core.Context) echo.MiddlewareFunc {
 				mockUserChecker := auth.NewMockUserChecker(t)
 				mockAccessChecker := auth.NewMockAccessChecker(t)
 
-				// Neither AccountExists nor CheckAccess should be called if no user in context
 				// Neither AccountExists nor CheckAccess should be called if no user in context
 				mockUserChecker.On("AccountExists", mock.Anything).Return(false, nil).Maybe()
 				mockAccessChecker.On("CheckAccess", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Maybe()

--- a/middleware/account_verified.go
+++ b/middleware/account_verified.go
@@ -1,16 +1,24 @@
 package middleware
 
 import (
-	"go.lumeweb.com/portal-middleware/auth/middleware"
-	"net/http"
-
+	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/portal-middleware/auth/adapter"
+	"go.lumeweb.com/portal-middleware/auth/middleware"
 	"go.lumeweb.com/portal/core"
 )
 
 // AccountVerifiedMiddleware creates middleware that checks if a user account is verified
 // using the core.UserService from the provided context.
-func AccountVerifiedMiddleware(ctx core.Context) func(http.Handler) http.Handler {
+func AccountVerifiedMiddleware(ctx core.Context) echo.MiddlewareFunc {
+	if ctx == nil {
+		panic("AccountVerifiedMiddleware requires a non-nil core.Context")
+	}
+	
+	userService := ctx.Service(core.USER_SERVICE)
+	if userService == nil {
+		panic("AccountVerifiedMiddleware requires core.USER_SERVICE to be registered in context")
+	}
+	
 	userChecker := adapter.NewUserCheckerFromCore(ctx)
 	return middleware.AccountVerified(userChecker)
 }

--- a/middleware/account_verified_test.go
+++ b/middleware/account_verified_test.go
@@ -1,8 +1,8 @@
 package middleware
 
 import (
-	"context"
 	"errors"
+	"github.com/labstack/echo/v4"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,26 +20,31 @@ func testAccountVerifiedMiddlewareHelper(t *testing.T, tests []struct {
 	userID         uint
 	path           string
 	expectedStatus int
-}, createMiddleware func(core.Context) func(http.Handler) http.Handler) {
+}, createMiddleware func(core.Context) echo.MiddlewareFunc) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			coreCtx := tt.setupContext()
 			middleware := createMiddleware(coreCtx)
 
-			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
+			e := echo.New()
+			e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+				return func(c echo.Context) error {
+					if tt.userID > 0 {
+						c.Set(string(mo.UserIDKey), tt.userID)
+					}
+					return next(c)
+				}
 			})
-			handler := middleware(testHandler)
+			e.Use(middleware)
+			e.GET(tt.path, func(c echo.Context) error {
+				return c.NoContent(http.StatusOK)
+			})
 
 			req := httptest.NewRequest("GET", tt.path, nil)
-			if tt.userID > 0 {
-				reqCtx := context.WithValue(req.Context(), mo.UserIDKey, tt.userID)
-				req = req.WithContext(reqCtx)
-			}
-
-			w := httptest.NewRecorder()
-			handler.ServeHTTP(w, req)
-			assert.Equal(t, tt.expectedStatus, w.Code, "Expected status code %d, got %d", tt.expectedStatus, w.Code)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+			
+			assert.Equal(t, tt.expectedStatus, rec.Code, "Expected status code %d, got %d", tt.expectedStatus, rec.Code)
 		})
 	}
 }
@@ -106,5 +111,7 @@ func TestAccountVerifiedMiddleware(t *testing.T) {
 		},
 	}
 
-	testAccountVerifiedMiddlewareHelper(t, tests, AccountVerifiedMiddleware)
+	testAccountVerifiedMiddlewareHelper(t, tests, func(ctx core.Context) echo.MiddlewareFunc {
+		return AccountVerifiedMiddleware(ctx)
+	})
 }

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -1,16 +1,16 @@
 package middleware
 
 import (
+	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/portal-middleware/auth/adapter"
 	"go.lumeweb.com/portal-middleware/auth/jwt"
 	"go.lumeweb.com/portal-middleware/auth/middleware"
 	"go.lumeweb.com/portal-middleware/auth/validation"
 	"go.lumeweb.com/portal/core"
-	"net/http"
 )
 
 // AuthMiddleware creates authentication middleware using core configuration
-func AuthMiddleware(ctx core.Context, purpose jwt.Purpose, options ...AuthOption) func(http.Handler) http.Handler {
+func AuthMiddleware(ctx core.Context, purpose jwt.Purpose, options ...AuthOption) echo.MiddlewareFunc {
 	config := adapter.NewFromCore(ctx)
 
 	opts := middleware.NewAuthOptions(

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	gjwt "github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal-middleware/auth/adapter"
 	"go.lumeweb.com/portal-middleware/auth/jwt"
@@ -41,46 +42,50 @@ func TestAuthMiddleware(t *testing.T) {
 
 		// Create test handler to verify context values
 		handlerCalled := false
-		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			handlerCalled = true
-
-			// Verify user ID was set in context
-			userID, err := mo.GetUserID(r.Context())
-			assert.NoError(t, err)
-			assert.Equal(t, uint(123), userID)
-
-			w.WriteHeader(http.StatusOK)
-		})
-
-		// Create test request with valid token
+		e := echo.New()
 		req := httptest.NewRequest("GET", "/", nil)
 		token := createTestToken(t, ctx, "123", "test-purpose")
 		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
 
-		rr := httptest.NewRecorder()
-		handler := middleware(testHandler)
-		handler.ServeHTTP(rr, req)
+		handlerCalled = false
+		testHandler := func(c echo.Context) error {
+			handlerCalled = true
 
+			// Verify user ID was set in context
+			userID, err := mo.GetUserID(c)
+			assert.NoError(t, err)
+			assert.Equal(t, uint(123), userID)
+
+			return c.NoContent(http.StatusOK)
+		}
+
+		// Apply middleware and call handler
+		err = middleware(testHandler)(c)
+		assert.NoError(t, err)
 		assert.True(t, handlerCalled)
-		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, http.StatusOK, rec.Code)
 	})
 
 	t.Run("empty allowed", func(t *testing.T) {
 		middleware := AuthMiddleware(ctx, "test-purpose", WithAuthEmptyAllowed(true))
 
-		handlerCalled := false
-		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			handlerCalled = true
-			w.WriteHeader(http.StatusOK)
-		})
-
+		e := echo.New()
 		req := httptest.NewRequest("GET", "/", nil) // No token
-		rr := httptest.NewRecorder()
-		handler := middleware(testHandler)
-		handler.ServeHTTP(rr, req)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
 
+		handlerCalled := false
+		testHandler := func(c echo.Context) error {
+			handlerCalled = true
+			return c.NoContent(http.StatusOK)
+		}
+
+		err = middleware(testHandler)(c)
+		assert.NoError(t, err)
 		assert.True(t, handlerCalled)
-		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, http.StatusOK, rec.Code)
 	})
 
 	t.Run("expired allowed", func(t *testing.T) {
@@ -92,34 +97,33 @@ func TestAuthMiddleware(t *testing.T) {
 			WithAuthValidator(mockValidator), // Use our mock validator
 		)
 
-		handlerCalled := false
-		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			handlerCalled = true
-
-			// Verify user ID was set from the expired token
-			userID, err := mcontext.GetUserID(r.Context())
-			assert.NoError(t, err)
-			assert.Equal(t, uint(123), userID)
-
-			w.WriteHeader(http.StatusOK)
-		})
-
-		// Create expired token
+		e := echo.New()
 		req := httptest.NewRequest("GET", "/", nil)
 		token := createTestToken(t, ctx, "123", "test-purpose", -time.Hour) // Expired 1 hour ago
 		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
 
 		claim := &gjwt.RegisteredClaims{Subject: "123"}
-
 		mockValidator.On("ValidateWithClaims", token, jwt.Purpose("test-purpose"), mock.Anything).
 			Return(claim, claim, nil)
 
-		rr := httptest.NewRecorder()
-		handler := middleware(testHandler)
-		handler.ServeHTTP(rr, req)
+		handlerCalled := false
+		testHandler := func(c echo.Context) error {
+			handlerCalled = true
 
+			// Verify user ID was set from the expired token
+			userID, err := mcontext.GetUserID(c)
+			assert.NoError(t, err)
+			assert.Equal(t, uint(123), userID)
+
+			return c.NoContent(http.StatusOK)
+		}
+
+		err = middleware(testHandler)(c)
+		assert.NoError(t, err)
 		assert.True(t, handlerCalled)
-		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, http.StatusOK, rec.Code)
 		mockValidator.AssertExpectations(t)
 	})
 }

--- a/middleware/option/option.go
+++ b/middleware/option/option.go
@@ -1,0 +1,43 @@
+package option
+
+import (
+	"github.com/labstack/echo/v4"
+	"go.lumeweb.com/portal-middleware/auth/jwt"
+	"go.lumeweb.com/portal-middleware/middleware"
+	router "go.lumeweb.com/portal-router"
+	"go.lumeweb.com/portal/core"
+)
+
+func WithVerification(ctx core.Context) router.RouteOption {
+	if ctx == nil {
+		panic("WithVerification requires a non-nil core.Context")
+	}
+
+	// Verify UserService exists early to fail fast
+	if ctx.Service(core.USER_SERVICE) == nil {
+		panic("WithVerification requires core.USER_SERVICE to be registered in context")
+	}
+
+	return func(d *router.RouteDefinition) {
+		d.Middlewares = append(d.Middlewares, middleware.AccountVerifiedMiddleware(ctx))
+	}
+}
+
+func With2FA(ctx core.Context) router.RouteOption {
+	return func(d *router.RouteDefinition) {
+		d.Middlewares = append(d.Middlewares, middleware.AuthMiddleware(ctx, jwt.Purpose2FA))
+	}
+}
+
+func WithAuth(ctx core.Context) router.RouteOption {
+	return func(d *router.RouteDefinition) {
+		d.Middlewares = append(d.Middlewares, middleware.AuthMiddleware(ctx, jwt.PurposeLogin))
+	}
+}
+
+// Middleware option
+func WithMiddleware(mw ...echo.MiddlewareFunc) router.RouteOption {
+	return func(d *router.RouteDefinition) {
+		d.Middlewares = append(d.Middlewares, mw...)
+	}
+}

--- a/tus/tus.go
+++ b/tus/tus.go
@@ -1,33 +1,27 @@
-// Package tus provides TUS protocol v1.0.0 extensions for resumable file uploads.
-// It implements:
-// - Location header modification for JWT token injection
-// - Response writer wrappers for protocol compliance
-// - Custom middleware integration with authentication system
 package tus
 
 import (
-	"go.lumeweb.com/gswagger"
-	gs "go.lumeweb.com/gswagger/support/gorilla"
-	"go.lumeweb.com/httputil"
+	"github.com/labstack/echo/v4"
+	swagger "go.lumeweb.com/gswagger"
+	mcontext "go.lumeweb.com/portal-middleware/context"
+	"go.lumeweb.com/portal-middleware/middleware/option"
+	"go.lumeweb.com/portal-middleware/util/convert"
+	"go.lumeweb.com/portal-router"
 	"go.lumeweb.com/portal/core"
 	"net/http"
 	"net/url"
 	"strings"
 
-	"github.com/gorilla/mux"
 	"github.com/rs/cors"
-	"go.lumeweb.com/portal-middleware/context"
 )
 
 // TUSProtocolHandler defines the interface for the underlying TUS protocol handler.
-type TUSProtocolHandler interface {
-	http.Handler
-}
+type TUSProtocolHandler = echo.HandlerFunc
 
 // LocationModifier defines an interface for modifying upload location URLs.
 // Used to inject authentication tokens into TUS protocol responses.
 type LocationModifier interface {
-	ModifyLocation(loc string, r *http.Request) string
+	ModifyLocation(loc string, c echo.Context) string
 }
 
 // jwtLocModifier implements LocationModifier to add JWT tokens to URLs
@@ -35,25 +29,9 @@ type jwtLocModifier struct {
 	ParamName string // Query parameter name to inject
 }
 
-type tusResponseWriter struct {
-	http.ResponseWriter
-	req             *http.Request
-	locationModifer LocationModifier
-}
-
-func (w *tusResponseWriter) WriteHeader(statusCode int) {
-	if statusCode == http.StatusCreated {
-		if location := w.Header().Get("Location"); location != "" {
-			w.Header().Set("Location", w.locationModifer.ModifyLocation(location, w.req))
-		}
-	}
-	w.ResponseWriter.WriteHeader(statusCode)
-}
-
 // Type assertions to ensure interfaces are implemented correctly
 var (
-	_ LocationModifier    = (*jwtLocModifier)(nil)
-	_ http.ResponseWriter = (*tusResponseWriter)(nil)
+	_ LocationModifier = (*jwtLocModifier)(nil)
 )
 
 func NewJWTLocModifier(paramName string) LocationModifier {
@@ -62,12 +40,15 @@ func NewJWTLocModifier(paramName string) LocationModifier {
 
 // ModifyLocation adds JWT token to location URL query parameters.
 // Implements LocationModifier interface.
-func (m *jwtLocModifier) ModifyLocation(loc string, r *http.Request) string {
-	authToken, _ := mcontext.GetAuthToken(r.Context())
-	if authToken != "" && loc != "" {
+func (m *jwtLocModifier) ModifyLocation(loc string, c echo.Context) string {
+	authToken := c.Get(string(mcontext.AuthTokenKey))
+	if authToken == nil {
+		return loc
+	}
+	if authTokenStr, ok := authToken.(string); ok && authTokenStr != "" && loc != "" {
 		parsedURL, _ := url.Parse(loc)
 		query := parsedURL.Query()
-		query.Set(m.ParamName, authToken)
+		query.Set(m.ParamName, authTokenStr)
 		parsedURL.RawQuery = query.Encode()
 		return parsedURL.String()
 	}
@@ -76,7 +57,7 @@ func (m *jwtLocModifier) ModifyLocation(loc string, r *http.Request) string {
 
 type locationModifierResponseWriter struct {
 	http.ResponseWriter
-	req             *http.Request
+	c               echo.Context
 	locationModifer LocationModifier
 }
 
@@ -84,170 +65,194 @@ func (w *locationModifierResponseWriter) WriteHeader(statusCode int) {
 	// Modify the Location header before writing headers
 	if statusCode == http.StatusCreated {
 		if location := w.Header().Get("Location"); location != "" {
-			w.Header().Set("Location", w.locationModifer.ModifyLocation(location, w.req))
+			w.Header().Set("Location", w.locationModifer.ModifyLocation(location, w.c))
 		}
 	}
 	w.ResponseWriter.WriteHeader(statusCode)
 }
 
-func PathMiddleware(basePath string, modifier LocationModifier) mux.MiddlewareFunc {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, basePath) {
-				trimmedPath := strings.TrimPrefix(r.URL.Path, basePath)
-				wasEmpty := trimmedPath == ""
-				if wasEmpty {
-					trimmedPath = "/"
-				}
-				r.URL.Path = trimmedPath
+// PathMiddleware is an echo.MiddlewareFunc that handles TUS path trimming and Location header modification.
+func PathMiddleware(basePath string, modifier LocationModifier) echo.MiddlewareFunc {
+	// Ensure basePath is clean with no trailing slashes
+	basePath = strings.TrimSuffix(basePath, "/")
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			r := c.Request()
+			w := c.Response()
 
-				res := w
-				if r.Method == http.MethodPost && wasEmpty && modifier != nil {
-					res = &locationModifierResponseWriter{
-						ResponseWriter:  w,
-						req:             r,
-						locationModifer: modifier,
-					}
-				}
-
-				next.ServeHTTP(res, r)
-			} else {
-				next.ServeHTTP(w, r)
+			if !strings.HasPrefix(r.URL.Path, basePath) {
+				return next(c) // Not the TUS base path, pass to next middleware/handler
 			}
-		})
+
+			trimmedPath := strings.TrimPrefix(r.URL.Path, basePath)
+			wasEmpty := trimmedPath == ""
+			if wasEmpty {
+				trimmedPath = "/"
+			}
+			r.URL.Path = trimmedPath // Modify the request path for the downstream handler
+
+			// Wrap the response writer if it's a POST request to the base path and a modifier exists
+			if r.Method == http.MethodPost && wasEmpty && modifier != nil {
+				// Create a new response writer that wraps the original one
+				wrappedWriter := &locationModifierResponseWriter{
+					ResponseWriter:  w,
+					c:               c, // Pass the echo.Context directly
+					locationModifer: modifier,
+				}
+				// Replace the response writer in the context
+				c.SetResponse(echo.NewResponse(wrappedWriter, c.Echo()))
+			}
+
+			// Call the next handler in the chain
+			return next(c)
+		}
 	}
 }
 
 func CorsMiddleware() func(h http.Handler) http.Handler {
 	return cors.New(cors.Options{
 		AllowOriginFunc: func(origin string) bool { return true },
-		AllowedMethods:  []string{http.MethodGet, http.MethodPost, http.MethodPatch, http.MethodDelete, http.MethodHead, http.MethodOptions},
-		AllowedHeaders: []string{
-			"authorization", "expires", "upload-concat",
-			"upload-length", "upload-metadata", "upload-offset",
-			"x-requested-with", "tus-version", "tus-resumable",
-			"tus-extension", "tus-max-size", "x-http-method-override",
-			"content-type",
+		AllowedMethods: []string{
+			http.MethodPost,
+			http.MethodHead,
+			http.MethodPatch,
+			http.MethodOptions,
+			http.MethodGet,
+			http.MethodDelete,
 		},
-		AllowCredentials:   true,
-		OptionsPassthrough: false,
+		AllowedHeaders: []string{
+			"authorization",
+			"origin",
+			"x-requested-with",
+			"x-request-id",
+			"x-http-method-override",
+			"content-type",
+			"upload-length",
+			"upload-offset",
+			"tus-resumable",
+			"upload-metadata",
+			"upload-defer-length",
+			"upload-concat",
+			"upload-incomplete",
+			"upload-complete",
+			"upload-draft-interop-version",
+		},
+		AllowCredentials: true,
 		ExposedHeaders: []string{
 			"Upload-Offset",
 			"Location",
 			"Upload-Length",
 			"Tus-Version",
 			"Tus-Resumable",
-			"Tus-Extension",
 			"Tus-Max-Size",
+			"Tus-Extension",
+			"Upload-Metadata",
+			"Upload-Defer-Length",
+			"Upload-Concat",
+			"Upload-Incomplete",
+			"Upload-Complete",
+			"Upload-Draft-Interop-Version",
 		},
+		MaxAge: 86400,
 	}).Handler
 }
 
+// dummyOptionsHandler is a placeholder handler for OPTIONS requests at the basePath.
+// The CORS middleware is expected to handle the response before this handler is reached.
+func dummyOptionsHandler(c echo.Context) error {
+	// This handler should ideally not be reached for CORS preflight requests
+	// because the CorsMiddleware should handle them and write the response.
+	// If it is reached, it means the CORS middleware didn't handle the request,
+	// or it's a non-preflight OPTIONS request.
+	// Returning 204 No Content is standard for OPTIONS if not handled by CORS.
+	return c.NoContent(http.StatusNoContent)
+}
+
+// RegisterTusRoutes registers TUS protocol routes using the router builder API.
+// It handles middleware chaining, access control registration and swagger documentation.
 // RegisterTusRoutes defines and registers the standard TUS upload routes.
 // It uses httputil Swagger helpers and applies TUS-specific middleware.
 func RegisterTusRoutes(
 	ctx core.Context,
-	gRouter *swagger.Router[gs.HandlerFunc, gs.Route],
+	grouter router.Router,
 	accessSvc core.AccessService,
 	subdomain string,
 	basePath string,
 	tusHandler TUSProtocolHandler,
 	authRequired bool,
-	verifiedRequired bool,
-	commonMiddleware ...mux.MiddlewareFunc,
+	twoFARequired bool,
+	commonMiddleware ...echo.MiddlewareFunc,
 ) error {
-	muxRouter := swagger.GetRouter[*mux.Router, gs.HandlerFunc, gs.Route](gRouter.Router())
-	// 1. Create a subrouter for the base path
-	subrouter := muxRouter.PathPrefix(basePath).Subrouter()
-	gsubrouter, err := gRouter.SubRouter(gs.NewRouter(subrouter), swagger.SubRouterOptions{})
+
+	subrouter, err := grouter.Group("")
 	if err != nil {
 		return err
 	}
 
-	// 2. Apply TUS-specific middleware to the subrouter
-	// Use the PathMiddleware from the tus middleware package
-	subrouter.Use(PathMiddleware(basePath, NewJWTLocModifier("token")))
-	// Use the CorsMiddleware from the tus middleware package
-	subrouter.Use(CorsMiddleware())
-	// Apply any additional common middleware passed in
-	subrouter.Use(commonMiddleware...)
+	// Create middleware chain
+	mw := router.Middlewares(
+		PathMiddleware(basePath, NewJWTLocModifier(core.AUTH_TOKEN_NAME)),
+		convert.Wrap(CorsMiddleware()),
+	)
+	mw = append(mw, commonMiddleware...)
 
 	// Determine access role based on authRequired
 	access := ""
 	if authRequired {
-		access = core.ACCESS_USER_ROLE // Or another appropriate role
+		access = core.ACCESS_USER_ROLE
 	}
 
-	// 3. Define the individual operation Swagger using httputil helpers
-	// Define error responses common to all TUS operations if any
-	// For now, using nil as in the original TusPostSwagger call
-	commonErrResp := map[int]any{} // Define common error responses here if needed
+	// Define error responses common to all TUS operations
+	commonErrResp := map[int]any{
+		http.StatusUnauthorized: "Authentication required",
+		http.StatusForbidden:    "Insufficient permissions",
+	}
 
-	postSwagger := httputil.TusPostSwagger("Create TUS Upload", "Creates a new TUS upload resource.", commonErrResp)
-	headSwagger := httputil.TusHeadSwagger("Get TUS Upload Status", "Retrieves the current offset and size of a TUS upload.", commonErrResp)
-	patchSwagger := httputil.TusPatchSwagger("Resume TUS Upload", "Appends data to an existing TUS upload resource.", commonErrResp)
-	deleteSwagger := httputil.TusDeleteSwagger("Terminate TUS Upload", "Terminates and removes a TUS upload resource.", commonErrResp)
-	optionsSwagger := httputil.TusOptionsSwagger("Get TUS Server Capabilities", "Retrieves information about the TUS server's supported versions, extensions, and limits.", commonErrResp)
+	// Helper to build route options based on auth requirements
+	buildRouteOptions := func(method string, path string, swaggerFn func(string, string, map[int]any) swagger.Definitions) router.RouteDefinition {
+		opts := router.DefineOptions(
+			router.WithSwagger(swaggerFn(
+				"TUS "+method+" "+path,
+				"TUS protocol "+method+" handler for "+path,
+				commonErrResp,
+			)),
+			router.WithMiddlewares(mw...),
+		)
 
-	// 4. Define the RouteDefinitions slice
-	routes := httputil.DefineRoutes(
-		httputil.RouteDefinition{
-			Path:      "", // Path relative to the subrouter's base path
-			Method:    http.MethodPost,
-			Handler:   tusHandler.ServeHTTP,
-			Access:    access,
-			UseVerify: verifiedRequired,
-			Use2FA:    false, // TUS typically doesn't require 2FA on these endpoints
-			Swagger:   postSwagger,
-		},
-		httputil.RouteDefinition{
-			Path:      "/{id}", // Path relative to the subrouter's base path
-			Method:    http.MethodHead,
-			Handler:   tusHandler.ServeHTTP,
-			Access:    access,
-			UseVerify: verifiedRequired,
-			Use2FA:    false,
-			Swagger:   headSwagger,
-		},
-		httputil.RouteDefinition{
-			Path:      "/{id}", // Path relative to the subrouter's base path
-			Method:    http.MethodPatch,
-			Handler:   tusHandler.ServeHTTP,
-			Access:    access,
-			UseVerify: verifiedRequired,
-			Use2FA:    false,
-			Swagger:   patchSwagger,
-		},
-		httputil.RouteDefinition{
-			Path:      "/{id}", // Path relative to the subrouter's base path
-			Method:    http.MethodDelete,
-			Handler:   tusHandler.ServeHTTP,
-			Access:    access, // Apply access control to DELETE as well
-			UseVerify: verifiedRequired,
-			Use2FA:    false,
-			Swagger:   deleteSwagger,
-		},
-		httputil.RouteDefinition{
-			Path:      "", // Path relative to the subrouter's base path
-			Method:    http.MethodOptions,
-			Handler:   tusHandler.ServeHTTP,
-			Access:    "", // OPTIONS is typically public
-			UseVerify: false,
-			Use2FA:    false,
-			Swagger:   optionsSwagger,
-		},
-		// Note: The OPTIONS method for /{id} is handled by the router automatically
-		// when OPTIONS is included in the Methods list for the /{id} routes.
-		// We don't need a separate RouteDefinition for it unless it requires
-		// different middleware or Swagger definitions (which it doesn't for TUS).
+		if authRequired {
+			if twoFARequired {
+				// Only require 2FA, not basic auth
+				opts = append(opts, option.With2FA(ctx), router.WithAccess(access))
+			} else {
+				// Require basic auth + verification
+				opts = append(opts, option.WithAuth(ctx), router.WithAccess(access))
+			}
+		}
+
+		return router.NewRoute(method, path, tusHandler, opts...)
+	}
+
+	// Define routes with their specific swagger docs and middleware
+	routes := router.DefineRoutes(
+		buildRouteOptions(http.MethodPost, basePath, router.TusPostSwagger),
+		buildRouteOptions(http.MethodHead, basePath+"/:id", router.TusHeadSwagger),
+		buildRouteOptions(http.MethodPatch, basePath+"/:id", router.TusPatchSwagger),
+		buildRouteOptions(http.MethodDelete, basePath+"/:id", router.TusDeleteSwagger),
+		router.NewRoute(
+			http.MethodOptions,
+			basePath,
+			dummyOptionsHandler,
+			router.WithSwagger(router.TusOptionsSwagger(
+				"Get TUS Server Capabilities",
+				"Retrieves information about the TUS server's supported versions, extensions, and limits.",
+				commonErrResp,
+			)),
+			router.WithMiddlewares(mw...),
+		),
 	)
 
-	// 5. Call httputil.RegisterRoutes to register the routes and Swagger
-	// Pass the subrouter, gRouter, accessSvc, subdomain, and the defined routes.
-	// No commonMiddleware is passed here as it was applied to the subrouter.
-	return httputil.RegisterRoutes(
-		ctx,
-		gsubrouter,
+	return router.RegisterRoutes(
+		subrouter,
 		accessSvc,
 		subdomain,
 		routes,

--- a/tus/tus_test.go
+++ b/tus/tus_test.go
@@ -2,45 +2,59 @@ package tus
 
 import (
 	"context"
-	"github.com/gorilla/mux"
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
-	"go.lumeweb.com/httputil"
+	"go.lumeweb.com/portal-middleware/auth/adapter"
+	"go.lumeweb.com/portal-middleware/auth/jwt"
+	router "go.lumeweb.com/portal-router"
+	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
+	"go.sia.tech/coreutils/wallet"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal-middleware/context"
-	"go.lumeweb.com/portal/core/testing/mocks"
+	coreMocks "go.lumeweb.com/portal/core/testing/mocks"
 )
 
 func TestJWTLocModifier(t *testing.T) {
 	modifier := NewJWTLocModifier("auth")
 
 	t.Run("adds token to query params", func(t *testing.T) {
+		e := echo.New()
 		req := httptest.NewRequest("POST", "/files", nil)
-		req = req.WithContext(context.WithValue(req.Context(), mcontext.AuthTokenKey, "test-token"))
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.Set(string(mcontext.AuthTokenKey), "test-token")
 
-		modified := modifier.ModifyLocation("/12345", req)
+		modified := modifier.ModifyLocation("/12345", c)
 		parsed, _ := url.Parse(modified)
 		assert.Equal(t, "test-token", parsed.Query().Get("auth"))
 	})
 
 	t.Run("no token in context", func(t *testing.T) {
+		e := echo.New()
 		req := httptest.NewRequest("POST", "/files", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
 
-		modified := modifier.ModifyLocation("/12345", req)
+		modified := modifier.ModifyLocation("/12345", c)
 		assert.Equal(t, "/12345", modified)
 	})
 
 	t.Run("empty location", func(t *testing.T) {
+		e := echo.New()
 		req := httptest.NewRequest("POST", "/files", nil)
 		req = req.WithContext(context.WithValue(req.Context(), mcontext.AuthTokenKey, "test-token"))
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
 
-		modified := modifier.ModifyLocation("", req)
+		modified := modifier.ModifyLocation("", c)
 		assert.Equal(t, "", modified)
 	})
 }
@@ -77,193 +91,253 @@ func TestCorsMiddleware(t *testing.T) {
 	})
 }
 
-func TestTusResponseWriter(t *testing.T) {
-	t.Run("modifies location header on 201", func(t *testing.T) {
-		modifier := &mockModifier{location: "modified"}
-		rr := httptest.NewRecorder()
-		w := &tusResponseWriter{
-			ResponseWriter:  rr,
-			req:             httptest.NewRequest("POST", "/", nil),
-			locationModifer: modifier,
-		}
-
-		w.Header().Set("Location", "original")
-		w.WriteHeader(http.StatusCreated)
-
-		assert.Equal(t, "modified", rr.Header().Get("Location"))
-	})
-
-	t.Run("doesnt modify other status codes", func(t *testing.T) {
-		modifier := &mockModifier{location: "modified"}
-		rr := httptest.NewRecorder()
-		w := &tusResponseWriter{
-			ResponseWriter:  rr,
-			req:             httptest.NewRequest("GET", "/", nil),
-			locationModifer: modifier,
-		}
-
-		w.Header().Set("Location", "original")
-		w.WriteHeader(http.StatusFound)
-
-		assert.Equal(t, "original", rr.Header().Get("Location"))
-	})
-
-	t.Run("preserves other headers", func(t *testing.T) {
-		modifier := &mockModifier{location: "modified"}
-		rr := httptest.NewRecorder()
-		w := &tusResponseWriter{
-			ResponseWriter:  rr,
-			req:             httptest.NewRequest("POST", "/", nil),
-			locationModifer: modifier,
-		}
-
-		w.Header().Set("X-Test", "value")
-		w.Header().Set("Location", "original")
-		w.WriteHeader(http.StatusCreated)
-
-		assert.Equal(t, "value", rr.Header().Get("X-Test"))
-	})
-
-	t.Run("handles empty location header", func(t *testing.T) {
-		modifier := &mockModifier{location: "modified"}
-		rr := httptest.NewRecorder()
-		w := &tusResponseWriter{
-			ResponseWriter:  rr,
-			req:             httptest.NewRequest("POST", "/", nil),
-			locationModifer: modifier,
-		}
-
-		w.WriteHeader(http.StatusCreated)
-		assert.Empty(t, rr.Header().Get("Location"))
-	})
-}
-
 func TestPathMiddleware(t *testing.T) {
 	basePath := "/files"
-	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/" {
-			w.WriteHeader(http.StatusBadRequest)
-			return
+
+	// Setup test handler that will be wrapped by middleware
+	testHandler := func(c echo.Context) error {
+		if c.Request().URL.Path != "/" {
+			return c.NoContent(http.StatusBadRequest)
 		}
-		w.Header().Set("Location", "/12345")
-		w.WriteHeader(http.StatusCreated)
-	})
+		c.Response().Header().Set("Location", "/12345")
+		return c.NoContent(http.StatusCreated)
+	}
 
 	t.Run("strips base path and preserves query params", func(t *testing.T) {
-		middleware := PathMiddleware(basePath, nil)
-		handler := middleware(testHandler)
+		e := echo.New()
+		e.Use(PathMiddleware(basePath, nil))
+		e.POST("/files", testHandler)
 
-		req := httptest.NewRequest("POST", "/files?test=1", nil)
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, req)
+		req := httptest.NewRequest(http.MethodPost, "/files?test=1", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
 
-		assert.Equal(t, http.StatusCreated, rr.Code)
-		assert.Equal(t, "/", req.URL.Path)
-		assert.Equal(t, "1", req.URL.Query().Get("test"))
+		assert.Equal(t, http.StatusCreated, rec.Code)
+		assert.Equal(t, "/12345", rec.Header().Get("Location"))
 	})
 
 	t.Run("handles nested paths", func(t *testing.T) {
-		middleware := PathMiddleware(basePath, nil)
-		handler := middleware(testHandler)
+		e := echo.New()
+		e.Use(PathMiddleware(basePath, nil))
+		e.POST("/files/nested", testHandler)
 
-		req := httptest.NewRequest("POST", "/files/nested", nil)
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, req)
+		req := httptest.NewRequest(http.MethodPost, "/files/nested", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
 
-		assert.Equal(t, http.StatusBadRequest, rr.Code)
-		assert.Equal(t, "/nested", req.URL.Path)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
 	})
 
 	t.Run("handles empty path", func(t *testing.T) {
-		middleware := PathMiddleware("", nil)
-		handler := middleware(testHandler)
+		e := echo.New()
+		e.Use(PathMiddleware("", nil))
+		e.POST("/", testHandler)
 
-		req := httptest.NewRequest("POST", "/", nil)
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, req)
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
 
-		assert.Equal(t, http.StatusCreated, rr.Code)
-		assert.Equal(t, "/", req.URL.Path)
+		assert.Equal(t, http.StatusCreated, rec.Code)
+		assert.Equal(t, "/12345", rec.Header().Get("Location"))
+	})
+
+	t.Run("modifies location header with auth token", func(t *testing.T) {
+		e := echo.New()
+		e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				c.Set(string(mcontext.AuthTokenKey), "test-token")
+				return next(c)
+			}
+		})
+		e.Use(PathMiddleware(basePath, NewJWTLocModifier("auth")))
+		e.POST("/files", testHandler)
+
+		req := httptest.NewRequest(http.MethodPost, "/files", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusCreated, rec.Code)
+		assert.Equal(t, "/12345?auth=test-token", rec.Header().Get("Location"))
 	})
 }
 
-type mockModifier struct {
-	location string
+func mockTUSHandler(c echo.Context) error {
+	switch c.Request().Method {
+	case http.MethodPost:
+		c.Response().Header().Set("Tus-Resumable", "1.0.0")
+		c.Response().Header().Set("Location", "/files/123")
+		return c.String(http.StatusCreated, "TUS post response")
+	case http.MethodOptions:
+		c.Response().Header().Set("Tus-Version", "1.0.0")
+		c.Response().Header().Set("Tus-Resumable", "1.0.0")
+		c.Response().Header().Set("Tus-Extension", "creation,termination")
+		return c.String(http.StatusOK, "TUS options response")
+	default:
+		return c.String(http.StatusOK, "TUS response")
+	}
 }
 
-func (m *mockModifier) ModifyLocation(loc string, r *http.Request) string {
-	return m.location
+func createTestToken(t *testing.T, ctx core.Context, subject string, purpose jwt.Purpose, expiresIn ...time.Duration) string {
+	config := adapter.NewFromCore(ctx)
+	expiry := time.Hour
+	if len(expiresIn) > 0 {
+		expiry = expiresIn[0]
+	}
+
+	token, err := jwt.CreateToken(
+		config.GetPrivateKey(),
+		config.GetDomain(),
+		subject,
+		purpose,
+		expiry,
+	)
+	require.NoError(t, err)
+	return token
 }
 
-type mockTUSHandler struct{}
-
-func (h *mockTUSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
+type tusTestSetup struct {
+	echoRouter *echo.Echo
+	gRouter    router.Router
+	accessSvc  *coreMocks.MockAccessService
+	userSvc    *coreMocks.MockUserService
+	ctx        core.Context
+	basePath   string
 }
 
-func TestRegisterTusRoutes(t *testing.T) {
-	ctx := coreTesting.NewTestContext(t)
-	mockRouter := mux.NewRouter()
-	gRouter, err := httputil.NewSwaggerRouter(mockRouter, httputil.APIInfo().
+func setupTusTest(t *testing.T) *tusTestSetup {
+	t.Helper()
+
+	echoRouter := echo.New()
+	gRouter, err := router.NewSwaggerRouter(echoRouter, router.APIInfo().
 		Title("TUS API").
 		Version("1.0.0"))
 	require.NoError(t, err)
 
-	accessSvc := mocks.NewMockAccessService(t)
-	accessSvc.EXPECT().CheckAccess(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
-	accessSvc.EXPECT().AssignRoleToUser(mock.Anything, mock.Anything).Return(nil).Maybe()
-	accessSvc.EXPECT().RegisterRoute("test", "", "POST", "user").Return(nil).Once()
-	accessSvc.EXPECT().RegisterRoute("test", "/{id}", "HEAD", "user").Return(nil).Once()
-	accessSvc.EXPECT().RegisterRoute("test", "/{id}", "PATCH", "user").Return(nil).Once()
-	accessSvc.EXPECT().RegisterRoute("test", "/{id}", "DELETE", "user").Return(nil).Once()
-	basePath := "/files"
-	tusHandler := &mockTUSHandler{}
+	accessSvc := coreMocks.NewMockAccessService(t)
+	userSvc := coreMocks.NewMockUserService(t)
+	ctx := coreTesting.NewTestContext(t)
+	ctx.RegisterService(core.USER_SERVICE, userSvc)
 
+	// Common expectations
+	accessSvc.EXPECT().CheckAccess(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
+	userSvc.On("IsAccountVerified", mock.Anything).Return(true, nil).Maybe()
+
+	seedPhrase := wallet.NewSeedPhrase()
+
+	cfg := ctx.Config()
+	err = cfg.Update("core.domain", "main.example.com")
+	if err != nil {
+		t.Error(err)
+	}
+	err = cfg.Update("core.identity", seedPhrase)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Expected route registrations
+	routeExpectations := []struct {
+		subdomain string
+		path      string
+		method    string
+		role      string
+	}{
+		{"test", "/files", "POST", "user"},
+		{"test", "/files/:id", "HEAD", "user"},
+		{"test", "/files/:id", "PATCH", "user"},
+		{"test", "/files/:id", "DELETE", "user"},
+		{"test", "/files", "OPTIONS", "user"},
+	}
+
+	for _, exp := range routeExpectations {
+		accessSvc.EXPECT().
+			RegisterRoute(exp.subdomain, exp.path, exp.method, exp.role).
+			Return(nil).
+			Once()
+	}
+
+	return &tusTestSetup{
+		echoRouter: echoRouter,
+		gRouter:    gRouter,
+		accessSvc:  accessSvc,
+		userSvc:    userSvc,
+		ctx:        ctx,
+		basePath:   "/files",
+	}
+}
+
+func TestRegisterTusRoutes(t *testing.T) {
 	t.Run("registers all TUS methods", func(t *testing.T) {
-		err := RegisterTusRoutes(ctx, gRouter, accessSvc, "test", basePath, tusHandler, false, false)
+		setup := setupTusTest(t)
+
+		err := RegisterTusRoutes(setup.ctx, setup.gRouter, setup.accessSvc, "test", setup.basePath, mockTUSHandler, false, false)
 		assert.NoError(t, err)
 
 		testCases := []struct {
-			method string
-			path   string
+			name           string
+			method         string
+			path           string
+			expectedStatus int
 		}{
-			{http.MethodPost, basePath},
-			{http.MethodHead, basePath + "/123"},
-			{http.MethodPatch, basePath + "/123"},
-			{http.MethodDelete, basePath + "/123"},
-			{http.MethodOptions, basePath},
+			{"POST", http.MethodPost, setup.basePath, http.StatusCreated},
+			{"HEAD", http.MethodHead, setup.basePath + "/123", http.StatusOK},
+			{"PATCH", http.MethodPatch, setup.basePath + "/123", http.StatusOK},
+			{"DELETE", http.MethodDelete, setup.basePath + "/123", http.StatusOK},
+			{"OPTIONS", http.MethodOptions, setup.basePath, http.StatusNoContent},
 		}
 
 		for _, tc := range testCases {
-			req := httptest.NewRequest(tc.method, tc.path, nil)
-			rr := httptest.NewRecorder()
-			mockRouter.ServeHTTP(rr, req)
-			assert.Equal(t, http.StatusOK, rr.Code, "failed for %s %s", tc.method, tc.path)
+			t.Run(tc.name, func(t *testing.T) {
+				req := httptest.NewRequest(tc.method, tc.path, nil)
+				rr := httptest.NewRecorder()
+				setup.echoRouter.ServeHTTP(rr, req)
+				assert.Equal(t, tc.expectedStatus, rr.Code)
+			})
 		}
 	})
 
-	t.Run("applies auth when required", func(t *testing.T) {
-		err := RegisterTusRoutes(ctx, gRouter, accessSvc, "test", basePath, tusHandler, true, false)
+	t.Run("requires authentication when enabled", func(t *testing.T) {
+		setup := setupTusTest(t)
+
+		err := RegisterTusRoutes(setup.ctx, setup.gRouter, setup.accessSvc, "test", setup.basePath, mockTUSHandler, true, false)
 		assert.NoError(t, err)
 
-		req := httptest.NewRequest(http.MethodPost, basePath, nil)
+		req := httptest.NewRequest(http.MethodPost, setup.basePath, nil)
 		rr := httptest.NewRecorder()
-		mockRouter.ServeHTTP(rr, req)
-		assert.Equal(t, http.StatusOK, rr.Code)
+		setup.echoRouter.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("allows access with valid token when auth enabled", func(t *testing.T) {
+		setup := setupTusTest(t)
+
+		err := RegisterTusRoutes(setup.ctx, setup.gRouter, setup.accessSvc, "test", setup.basePath, mockTUSHandler, true, false)
+		assert.NoError(t, err)
+
+		token := createTestToken(t, setup.ctx, "123", jwt.Purpose("login"))
+		req := httptest.NewRequest(http.MethodPost, setup.basePath, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rr := httptest.NewRecorder()
+		setup.echoRouter.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusCreated, rr.Code)
 	})
 
 	t.Run("applies CORS headers", func(t *testing.T) {
-		err := RegisterTusRoutes(ctx, gRouter, accessSvc, "test", basePath, tusHandler, false, false)
+		setup := setupTusTest(t)
+
+		err := RegisterTusRoutes(setup.ctx, setup.gRouter, setup.accessSvc, "test", setup.basePath, mockTUSHandler, false, false)
 		assert.NoError(t, err)
 
-		req := httptest.NewRequest(http.MethodOptions, basePath, nil)
+		req := httptest.NewRequest(http.MethodOptions, setup.basePath, nil)
 		req.Header.Set("Origin", "http://example.com")
 		req.Header.Set("Access-Control-Request-Method", "POST")
+		req.Header.Set("Access-Control-Request-Headers", "upload-offset")
 		rr := httptest.NewRecorder()
-		mockRouter.ServeHTTP(rr, req)
+		setup.echoRouter.ServeHTTP(rr, req)
 
-		assert.Equal(t, "http://example.com", rr.Header().Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "POST", rr.Header().Get("Access-Control-Allow-Methods"))
+		headers := rr.Header()
+		assert.Equal(t, "http://example.com", headers.Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "POST", headers.Get("Access-Control-Allow-Methods"))
+		assert.Equal(t, "true", headers.Get("Access-Control-Allow-Credentials"))
 	})
 
 }

--- a/util/convert/convert.go
+++ b/util/convert/convert.go
@@ -1,0 +1,58 @@
+package convert
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Wrap converts a standard http.Handler middleware to an echo.MiddlewareFunc.
+// It properly propagates errors from the echo handler chain.
+func Wrap(mw func(http.Handler) http.Handler) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			var handlerErr error
+			
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				c.SetRequest(r)
+				handlerErr = next(c)
+			}))
+			
+			handler.ServeHTTP(c.Response(), c.Request())
+			return handlerErr
+		}
+	}
+}
+
+// Unwrap converts an echo.MiddlewareFunc to a standard http.Handler middleware.
+func Unwrap(mw echo.MiddlewareFunc) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			e := echo.New()
+			c := e.NewContext(r, w)
+			
+			handler := mw(func(c echo.Context) error {
+				next.ServeHTTP(c.Response(), c.Request())
+				return nil
+			})
+			
+			// Execute the middleware chain and handle any errors
+			if err := handler(c); err != nil {
+				e.HTTPErrorHandler(err, c)
+			}
+		})
+	}
+}
+
+// HTTPHandler converts a standard http.Handler to an echo.HandlerFunc.
+func HTTPHandler(h http.Handler) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		h.ServeHTTP(c.Response(), c.Request())
+		return nil
+	}
+}
+
+// HTTPHandlerFunc converts a standard http.HandlerFunc to an echo.HandlerFunc.
+func HTTPHandlerFunc(h http.HandlerFunc) echo.HandlerFunc {
+	return HTTPHandler(h)
+}

--- a/util/convert/convert_test.go
+++ b/util/convert/convert_test.go
@@ -1,0 +1,153 @@
+package convert
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrap(t *testing.T) {
+	t.Run("wraps http middleware correctly", func(t *testing.T) {
+		httpMW := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-Test", "true")
+				next.ServeHTTP(w, r)
+			})
+		}
+
+		echoMW := Wrap(httpMW)
+
+		e := echo.New()
+		e.Use(echoMW)
+		e.GET("/", func(c echo.Context) error {
+			return c.String(http.StatusOK, "test")
+		})
+
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, "true", rec.Header().Get("X-Test"))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "test", rec.Body.String())
+	})
+
+	t.Run("propagates echo errors", func(t *testing.T) {
+		httpMW := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				next.ServeHTTP(w, r)
+			})
+		}
+
+		echoMW := Wrap(httpMW)
+
+		e := echo.New()
+		e.Use(echoMW)
+		e.GET("/", func(c echo.Context) error {
+			return echo.NewHTTPError(http.StatusBadRequest, "test error")
+		})
+
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "test error")
+	})
+}
+
+func TestUnwrap(t *testing.T) {
+	t.Run("unwraps echo middleware correctly", func(t *testing.T) {
+		echoMW := func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				c.Response().Header().Set("X-Test", "true")
+				return next(c)
+			}
+		}
+
+		httpMW := Unwrap(echoMW)
+
+		handler := httpMW(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("test"))
+		}))
+
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, "true", rec.Header().Get("X-Test"))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "test", rec.Body.String())
+	})
+
+	t.Run("handles echo errors", func(t *testing.T) {
+		echoMW := func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				return echo.NewHTTPError(http.StatusBadRequest, "test error")
+			}
+		}
+
+		httpMW := Unwrap(echoMW)
+
+		handler := httpMW(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("next handler should not be called")
+		}))
+
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "test error")
+	})
+}
+
+func TestHTTPHandler(t *testing.T) {
+	t.Run("converts http.Handler to echo.HandlerFunc", func(t *testing.T) {
+		httpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Test", "true")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("test"))
+		})
+
+		echoHandler := HTTPHandler(httpHandler)
+
+		e := echo.New()
+		e.GET("/", echoHandler)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, "true", rec.Header().Get("X-Test"))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "test", rec.Body.String())
+	})
+}
+
+func TestHTTPHandlerFunc(t *testing.T) {
+	t.Run("converts http.HandlerFunc to echo.HandlerFunc", func(t *testing.T) {
+		httpHandler := func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Test", "true")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("test"))
+		}
+
+		echoHandler := HTTPHandlerFunc(httpHandler)
+
+		e := echo.New()
+		e.GET("/", echoHandler)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, "true", rec.Header().Get("X-Test"))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "test", rec.Body.String())
+	})
+}

--- a/util/util.go
+++ b/util/util.go
@@ -10,6 +10,7 @@ import (
 	"go.lumeweb.com/portal-middleware/auth/jwt"
 	"go.lumeweb.com/portal-middleware/auth/middleware"
 	"go.lumeweb.com/portal-middleware/cors"
+	"go.lumeweb.com/portal-middleware/util/convert"
 	"go.lumeweb.com/portal/core"
 	"net/http"
 )
@@ -39,11 +40,11 @@ func (m *Middleware) Then() http.Handler {
 // WithAuth adds authentication middleware to the chain.
 // Configures JWT validation with the specified purpose and configuration.
 func (m *Middleware) WithAuth(config adapter.ConfigProvider, purpose jwt.Purpose) *Middleware {
-	return m.Chain(middleware.AuthMiddleware(middleware.AuthMiddlewareOptions{
+	return m.Chain(convert.Unwrap(middleware.AuthMiddleware(middleware.AuthMiddlewareOptions{
 		Config:         config,
 		Purpose:        purpose,
 		ExpiredAllowed: false,
-	}))
+	})))
 }
 
 // WithAuthFromCore adds authentication middleware using core.Context


### PR DESCRIPTION
- Convert all middleware handlers from standard net/http to echo.MiddlewareFunc
- Update context handling to use echo.Context instead of http.Request context
- Modify JWT claims storage to work with echo's context system
- Refactor tests to use echo's testing patterns
- Add new utility functions for http/echo handler conversion
- Update CORS and TUS handlers to be echo-compatible
- Remove unused shared test file
- Update go.mod dependencies to include echo framework

This major refactor changes the underlying web framework while maintaining all existing functionality. The changes include:
- Middleware now returns echo.HandlerFunc instead of http.Handler
- Context values are stored using echo.Context.Set() instead of context.WithValue()
- Error handling follows echo's error return pattern
- Tests are updated to use echo's test helpers
- Added new convert package for http/echo interoperability