### PR TITLE
refactor: migrate from gorilla/mux to echo framework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,14 +7,12 @@ toolchain go1.23.7
 require (
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
-	github.com/gorilla/mux v1.8.2-0.20240619235004-db9d1d0073d2
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.10.0
-	go.lumeweb.com/gswagger v0.15.0
-	go.lumeweb.com/httputil v0.4.2
+	go.lumeweb.com/gswagger v0.16.0
 	go.lumeweb.com/portal v0.4.2-0.20250504192002-4547d95e5a02
-	go.lumeweb.com/portal-router v0.1.8
+	go.lumeweb.com/portal-router v0.1.9
 	go.sia.tech/coreutils v0.12.1
 	gorm.io/gorm v1.25.12
 )
@@ -22,7 +20,6 @@ require (
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/AfterShip/email-verifier v1.4.1 // indirect
-	github.com/Oudwins/zog v0.18.4 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.36.3 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
@@ -56,6 +53,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gookit/event v1.1.2 // indirect
+	github.com/gorilla/mux v1.8.2-0.20240619235004-db9d1d0073d2 // indirect
 	github.com/gotd/contrib v0.21.0 // indirect
 	github.com/hbollon/go-edlib v1.6.0 // indirect
 	github.com/invopop/jsonschema v0.12.0 // indirect
@@ -104,7 +102,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.38.0 // indirect
-	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect

--- a/route_builder_options.go
+++ b/route_builder_options.go
@@ -1,28 +1,28 @@
 package middleware
 
 import (
-	"github.com/gorilla/mux"
-	"go.lumeweb.com/httputil"
+	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/portal-middleware/auth/jwt"
 	"go.lumeweb.com/portal-middleware/middleware"
+	router "go.lumeweb.com/portal-router"
 	"go.lumeweb.com/portal/core"
 )
 
-func WithVerification(ctx core.Context) httputil.RouteOption {
-	return func(d *httputil.RouteDefinition) {
+func WithVerification(ctx core.Context) router.RouteOption {
+	return func(d *router.RouteDefinition) {
 		d.Middlewares = append(d.Middlewares, middleware.AccountVerifiedMiddleware(ctx))
 	}
 }
 
-func With2FA(ctx core.Context) httputil.RouteOption {
-	return func(d *httputil.RouteDefinition) {
+func With2FA(ctx core.Context) router.RouteOption {
+	return func(d *router.RouteDefinition) {
 		d.Middlewares = append(d.Middlewares, middleware.AuthMiddleware(ctx, jwt.Purpose2FA))
 	}
 }
 
 // Middleware option
-func WithMiddleware(mw ...mux.MiddlewareFunc) httputil.RouteOption {
-	return func(d *httputil.RouteDefinition) {
+func WithMiddleware(mw ...echo.MiddlewareFunc) router.RouteOption {
+	return func(d *router.RouteDefinition) {
 		d.Middlewares = append(d.Middlewares, mw...)
 	}
 }

--- a/route_builder_options_test.go
+++ b/route_builder_options_test.go
@@ -1,45 +1,45 @@
 package middleware
 
 import (
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
-	"go.lumeweb.com/httputil"
+	router "go.lumeweb.com/portal-router"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 	"go.lumeweb.com/portal/core/testing/mocks"
-	"net/http"
 	"testing"
 )
 
 func TestWithVerification(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {}
+	handler := func(c echo.Context) error { return nil }
 	ctx := coreTesting.NewTestContext(t)
 
 	// Setup mock expectations
 	mockUser := mocks.NewMockUserService(t)
 	ctx.RegisterService(core.USER_SERVICE, mockUser)
 
-	route := httputil.NewRoute("GET", "/test", handler, WithVerification(ctx))
+	route := router.NewRoute("GET", "/test", handler, WithVerification(ctx))
 
 	assert.Len(t, route.Middlewares, 1)
 	mockUser.AssertExpectations(t)
 }
 
 func TestWith2FA(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {}
+	handler := func(c echo.Context) error { return nil }
 	ctx := mocks.NewMockContext(t)
 
-	route := httputil.NewRoute("GET", "/test", handler, With2FA(ctx))
+	route := router.NewRoute("GET", "/test", handler, With2FA(ctx))
 
 	assert.Len(t, route.Middlewares, 1)
 }
 
 func TestWithMiddleware(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {}
-	mw := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	handler := func(c echo.Context) error { return nil }
+	mw := func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error { return nil }
 	}
 
-	route := httputil.NewRoute("GET", "/test", handler, WithMiddleware(mw))
+	route := router.NewRoute("GET", "/test", handler, WithMiddleware(mw))
 
 	assert.Len(t, route.Middlewares, 1)
 }

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -5,48 +5,45 @@ import (
 	"embed"
 	"fmt"
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/labstack/echo/v4"
+	"go.lumeweb.com/portal-router"
 	"io/fs"
 	"net/http"
-
-	"github.com/gorilla/mux"
 )
 
 //go:embed embed
 var swagfs embed.FS
 
-// WireRouter wires swagger UI endpoints to an existing mux.Router.
+// WireRouter wires swagger UI endpoints to an existing router.Router.
 // It configures the UI to fetch the OpenAPI spec from the specified specPath.
-// This function is intended to be used in conjunction with a mechanism
-// that serves the OpenAPI spec itself (e.g., gswagger integrated via httputil).
 //
 // Parameters:
-// - router: The mux.Router to wire the Swagger UI handlers to.
-// - specPath: The URL path where the OpenAPI JSON spec is served (e.g., "/swagger.json").
-// - uiPathPrefix: The URL path prefix where the Swagger UI will be served (e.g., "/swagger").
-func WireRouter(router *mux.Router, specPath string, uiPathPrefix string) error {
-	// Ensure the specPath is valid
+// - router: The router.Router to wire the Swagger UI handlers to
+// - specPath: The URL path where the OpenAPI JSON spec is served (e.g., "/swagger.json")
+// - uiPathPrefix: The URL path prefix where the Swagger UI will be served (e.g., "/swagger")
+func WireRouter(_router router.Router, specPath string, uiPathPrefix string) error {
 	if specPath == "" {
 		return fmt.Errorf("specPath cannot be empty")
 	}
-	// Ensure the uiPathPrefix is valid
 	if uiPathPrefix == "" || uiPathPrefix[0] != '/' {
 		return fmt.Errorf("uiPathPrefix must start with '/' and cannot be empty")
 	}
 
-	// Serve the static Swagger UI files
 	swaggerFiles, err := fs.Sub(swagfs, "embed")
 	if err != nil {
 		return fmt.Errorf("failed to get embedded swagger files: %w", err)
 	}
-	swaggerHandler := http.StripPrefix(uiPathPrefix, http.FileServer(http.FS(swaggerFiles)))
 
-	// Redirect from the base UI path to the index.html
-	router.HandleFunc(uiPathPrefix, func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, uiPathPrefix+"/", http.StatusMovedPermanently)
-	}).Methods("GET")
+	// Create file server handler
+	fileServer := http.FileServer(http.FS(swaggerFiles))
 
-	// Serve the static files under the path prefix
-	router.PathPrefix(uiPathPrefix + "/").Handler(swaggerHandler)
+	// Register routes with router
+	router.GetRouter(_router).GET(uiPathPrefix, func(c echo.Context) error {
+		return c.Redirect(http.StatusMovedPermanently, uiPathPrefix+"/")
+	})
+
+	// Serve static files under the prefix
+	router.GetRouter(_router).GET(uiPathPrefix+"/*", echo.WrapHandler(http.StripPrefix(uiPathPrefix, fileServer)))
 
 	// Note: This package no longer serves the spec itself.
 	// The spec is expected to be served by another handler,
@@ -62,26 +59,16 @@ func WireRouter(router *mux.Router, specPath string, uiPathPrefix string) error 
 }
 
 // NewStandaloneHandler creates an HTTP handler that serves the Swagger UI.
-// It configures the UI to fetch the OpenAPI spec from the specified specPath.
-// This is useful for serving the UI from a single handler, assuming the spec
-// is available at the given specPath.
-//
-// Parameters:
-// - specPath: The URL path where the OpenAPI JSON spec is served (e.g., "/swagger.json").
-// - uiPathPrefix: The URL path prefix where the Swagger UI will be served (e.g., "/swagger").
-//
-// Returns:
-// - http.Handler: The configured handler serving the Swagger UI.
-// - error: Any error encountered during setup.
-func NewStandaloneHandler(specPath string, uiPathPrefix string) (http.Handler, error) {
-	router := mux.NewRouter()
-	if err := WireRouter(router, specPath, uiPathPrefix); err != nil {
+func NewStandaloneHandler(specPath string, uiPathPrefix string) (router.Router, error) {
+	_router, err := router.NewRouter(router.APIInfo().Title("Swagger").Version("0.1.0"))
+	if err != nil {
 		return nil, err
 	}
-	return router, nil
+	if err = WireRouter(_router, specPath, uiPathPrefix); err != nil {
+		return nil, err
+	}
+	return _router, nil
 }
-
-// --- Deprecated Functions ---
 
 // LoadAndValidateSpec is deprecated. Spec loading and validation
 // should be handled by the spec generation mechanism (e.g., gswagger).
@@ -105,24 +92,11 @@ func LoadAndValidateSpec(spec []byte) ([]byte, error) {
 	return doc.MarshalJSON()
 }
 
-// NewHandler is deprecated. Use WireRouter in conjunction with a spec
-// generation mechanism (like gswagger) instead.
-//
-// Deprecated: Use WireRouter instead.
-func NewHandler(spec []byte, router *mux.Router) error {
-	// This function combined spec loading/validation with wiring.
-	// In the new model, spec generation is separate.
-	// Keeping for backward compatibility, but marked deprecated.
-	// It now calls the deprecated LoadAndValidateSpec and the new WireRouter.
+// NewHandler is deprecated.
+func NewHandler(spec []byte, router router.Router) error {
 	_, err := LoadAndValidateSpec(spec)
 	if err != nil {
 		return err
 	}
-
-	// Assuming the spec will be served at "/swagger.json" by the gswagger integration
-	// This might need adjustment if gswagger serves it elsewhere.
-	// A better approach might be to remove this deprecated function entirely
-	// or require the specPath as a parameter. For now, assuming default.
-	WireRouter(router, "/swagger.json", "/swagger") // Assuming default paths
-	return nil
+	return WireRouter(router, "/swagger.json", "/swagger")
 }

--- a/swagger/swagger_test.go
+++ b/swagger/swagger_test.go
@@ -1,11 +1,11 @@
 package swagger
 
 import (
+	"go.lumeweb.com/portal-router"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,10 +34,14 @@ func TestLoadAndValidateSpec(t *testing.T) {
 
 func TestWireRouter(t *testing.T) {
 	t.Run("wires routes correctly", func(t *testing.T) {
-		router := mux.NewRouter()
-		err := WireRouter(router, "/api/spec.json", "/docs")
+		_router, err := router.NewRouter(router.APIInfo().
+			Title("Test API").
+			Version("1.0.0"))
 		require.NoError(t, err)
-		
+
+		err = WireRouter(_router, "/api/spec.json", "/docs")
+		require.NoError(t, err)
+
 		tests := []struct {
 			method string
 			path   string
@@ -47,18 +51,21 @@ func TestWireRouter(t *testing.T) {
 			{"GET", "/docs/", http.StatusOK},
 			{"GET", "/docs/swagger-initializer.js", http.StatusOK},
 		}
-		
+
 		for _, tt := range tests {
 			req := httptest.NewRequest(tt.method, tt.path, nil)
 			w := httptest.NewRecorder()
-			router.ServeHTTP(w, req)
+			_router.ServeHTTP(w, req)
 			assert.Equal(t, tt.status, w.Code, "path: %s", tt.path)
 		}
 	})
 
 	t.Run("invalid paths", func(t *testing.T) {
-		router := mux.NewRouter()
-		
+		_router, err := router.NewRouter(router.APIInfo().
+			Title("Test API").
+			Version("1.0.0"))
+		require.NoError(t, err)
+
 		tests := []struct {
 			name      string
 			specPath  string
@@ -84,10 +91,10 @@ func TestWireRouter(t *testing.T) {
 				expectErr: "uiPathPrefix must start with '/' and cannot be empty",
 			},
 		}
-		
+
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				err := WireRouter(router, tt.specPath, tt.uiPrefix)
+				err := WireRouter(_router, tt.specPath, tt.uiPrefix)
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectErr)
 			})
@@ -106,20 +113,22 @@ func TestNewHandler(t *testing.T) {
 	}`)
 
 	t.Run("wires UI routes correctly", func(t *testing.T) {
-		router := mux.NewRouter()
-		err := NewHandler(mockSpec, router)
+		_router, err := router.NewRouter(router.APIInfo().
+			Title("Test API").
+			Version("1.0.0"))
 		require.NoError(t, err)
-		
-		// Test UI routes instead of spec endpoint
+
+		err = NewHandler(mockSpec, _router)
+		require.NoError(t, err)
+
 		req := httptest.NewRequest("GET", "/swagger", nil)
 		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-		
+		_router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusMovedPermanently, w.Code)
-		
+
 		req = httptest.NewRequest("GET", "/swagger/", nil)
 		w = httptest.NewRecorder()
-		router.ServeHTTP(w, req)
+		_router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
 	})
@@ -129,7 +138,7 @@ func TestNewStandaloneHandler(t *testing.T) {
 	t.Run("creates valid handler", func(t *testing.T) {
 		handler, err := NewStandaloneHandler("/api/spec.json", "/docs")
 		require.NoError(t, err)
-		
+
 		tests := []struct {
 			method string
 			path   string
@@ -138,7 +147,7 @@ func TestNewStandaloneHandler(t *testing.T) {
 			{"GET", "/docs", http.StatusMovedPermanently},
 			{"GET", "/docs/", http.StatusOK},
 		}
-		
+
 		for _, tt := range tests {
 			req := httptest.NewRequest(tt.method, tt.path, nil)
 			w := httptest.NewRecorder()


### PR DESCRIPTION
- Updated go.mod dependencies:
  - Removed direct dependency on gorilla/mux
  - Upgraded gswagger to v0.16.0
  - Upgraded portal-router to v0.1.9
  - Removed unused dependencies (httputil, Oudwins/zog, golang.org/x/exp)

- Refactored route builder options to use echo middleware instead of gorilla/mux:
  - Changed RouteOption signature to use echo.MiddlewareFunc
  - Updated tests accordingly

- Rewrote swagger integration to work with echo router:
  - Modified WireRouter to use echo router methods
  - Updated NewStandaloneHandler to return router.Router
  - Simplified handler registration
  - Maintained backward compatibility with deprecated functions

- Updated test files to use echo context and handlers