### PR TITLE
chore(deps): update dependencies and fix swagger options signature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,9 @@ require (
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.10.0
-	go.lumeweb.com/gswagger v0.16.1
+	go.lumeweb.com/gswagger v0.17.0
 	go.lumeweb.com/portal v0.4.2-0.20250504192002-4547d95e5a02
-	go.lumeweb.com/portal-router v0.2.1
+	go.lumeweb.com/portal-router v0.3.2
 	go.sia.tech/coreutils v0.12.1
 	gorm.io/gorm v1.25.12
 )
@@ -56,7 +56,7 @@ require (
 	github.com/gorilla/mux v1.8.2-0.20240619235004-db9d1d0073d2 // indirect
 	github.com/gotd/contrib v0.21.0 // indirect
 	github.com/hbollon/go-edlib v1.6.0 // indirect
-	github.com/invopop/jsonschema v0.12.0 // indirect
+	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
@@ -95,6 +95,7 @@ require (
 	go.etcd.io/etcd/api/v3 v3.5.19 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.19 // indirect
 	go.etcd.io/etcd/client/v3 v3.5.19 // indirect
+	go.lumeweb.com/queryutil v0.3.2 // indirect
 	go.sia.tech/core v0.10.4 // indirect
 	go.sia.tech/jape v0.12.1 // indirect
 	go.sia.tech/mux v1.4.0 // indirect
@@ -102,10 +103,11 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.38.0 // indirect
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
-	golang.org/x/tools v0.31.0 // indirect
+	golang.org/x/tools v0.33.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
 	google.golang.org/grpc v1.71.0 // indirect

--- a/tus/tus.go
+++ b/tus/tus.go
@@ -211,7 +211,7 @@ func RegisterTusRoutes(
 	// Helper to build route options based on auth requirements
 	buildRouteOptions := func(method string, path string, swaggerFn func(string, string, map[int]any) swagger.Definitions) router.RouteDefinition {
 		opts := router.DefineOptions(
-			router.WithSwaggerOptions(func(d *swagger.Definitions) {
+			router.WithSwaggerOptions(func(d *swagger.Definitions, _ string) {
 				*d = swaggerFn(
 					"TUS "+method+" "+path,
 					"TUS protocol "+method+" handler for "+path,
@@ -244,9 +244,9 @@ func RegisterTusRoutes(
 			http.MethodOptions,
 			basePath,
 			dummyOptionsHandler,
-			router.WithSwaggerOptions(func(d *swagger.Definitions) {
+			router.WithSwaggerOptions(func(d *swagger.Definitions, _ string) {
 				*d = router.TusOptionsSwagger(
-					"Get TUS Server Capabilities", 
+					"Get TUS Server Capabilities",
 					"Retrieves information about the TUS server's supported versions, extensions, and limits.",
 					commonErrResp,
 				)


### PR DESCRIPTION
- Updated multiple dependencies in go.mod including:
  - go.lumeweb.com/gswagger v0.16.1 → v0.17.0
  - go.lumeweb.com/portal-router v0.2.1 → v0.3.2
  - github.com/invopop/jsonschema v0.12.0 → v0.13.0
  - golang.org/x/tools v0.31.0 → v0.33.0
- Added new dependency: go.lumeweb.com/queryutil v0.3.2
- Updated tus.go to match new swagger options signature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated several dependencies to newer versions for improved stability and compatibility.

- **Refactor**
	- Adjusted internal route configuration to support updated dependency interfaces. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->