### PR TITLE
refactor(auth): simplify auth middleware options initialization

### DIFF
--- a/auth/middleware/auth.go
+++ b/auth/middleware/auth.go
@@ -170,15 +170,10 @@ func AuthMiddleware(options AuthMiddlewareOptions) echo.MiddlewareFunc {
 }
 
 // NewAuthOptions creates and configures AuthMiddlewareOptions in one step
-func NewAuthOptions(config adapter.ConfigProvider, purposes []jwt.Purpose, opts ...AuthMiddlewareOption) *AuthMiddlewareOptions {
-	// Defensively copy and sanitize purposes (drop empty, de-duplicate)
-	clean := lo.Uniq(lo.Filter(purposes, func(p jwt.Purpose, _ int) bool {
-		return p != ""
-	}))
-
+func NewAuthOptions(config adapter.ConfigProvider, opts ...AuthMiddlewareOption) *AuthMiddlewareOptions {
 	options := &AuthMiddlewareOptions{
 		Config:         config,
-		Purposes:       clean,
+		Purposes:       nil,   // must be set via WithPurpose
 		EmptyAllowed:   false, // default
 		ExpiredAllowed: false, // default
 		ErrorCallback:  nil,   // default
@@ -200,9 +195,13 @@ func WithConfig(config adapter.ConfigProvider) AuthMiddlewareOption {
 // WithPurpose sets the JWT purposes for the options
 func WithPurpose(purposes ...jwt.Purpose) AuthMiddlewareOption {
 	return func(opts *AuthMiddlewareOptions) {
-		opts.Purposes = lo.Uniq(lo.Filter(purposes, func(p jwt.Purpose, _ int) bool {
+		clean := lo.Uniq(lo.Filter(purposes, func(p jwt.Purpose, _ int) bool {
 			return p != ""
 		}))
+		if len(clean) == 0 {
+			panic("WithPurpose requires at least one non-empty purpose")
+		}
+		opts.Purposes = clean
 	}
 }
 

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -10,16 +10,17 @@ import (
 )
 
 // AuthMiddleware creates authentication middleware using core configuration
-func AuthMiddleware(ctx core.Context, purposes []jwt.Purpose, options ...AuthOption) echo.MiddlewareFunc {
+func AuthMiddleware(ctx core.Context, options ...AuthOption) echo.MiddlewareFunc {
 	config := adapter.NewFromCore(ctx)
 
-	opts := middleware.NewAuthOptions(
-		config,
-		purposes,
-	)
-
+	opts := middleware.NewAuthOptions(config)
 	for _, option := range options {
 		option(opts)
+	}
+
+	// Ensure at least one purpose is set
+	if len(opts.Purposes) == 0 {
+		panic("AuthMiddleware requires at least one purpose to be set via WithAuthPurpose")
 	}
 
 	return middleware.AuthMiddleware(*opts)
@@ -55,7 +56,8 @@ func WithAuthPurpose(purposes ...jwt.Purpose) AuthOption {
 
 // AuthMiddlewareSinglePurpose is a convenience wrapper for AuthMiddleware that accepts a single purpose
 func AuthMiddlewareSinglePurpose(ctx core.Context, purpose jwt.Purpose, options ...AuthOption) echo.MiddlewareFunc {
-	return AuthMiddleware(ctx, []jwt.Purpose{purpose}, options...)
+	options = append(options, WithAuthPurpose(purpose))
+	return AuthMiddleware(ctx, options...)
 }
 
 // AuthErrorCallback defines a function type that takes a context and returns an error code and JSON serializable response


### PR DESCRIPTION
- Removed purposes parameter from NewAuthOptions constructor
- Made purposes required via WithPurpose option
- Added validation to ensure at least one purpose is provided
- Updated AuthMiddleware to use new options pattern
- Modified AuthMiddlewareSinglePurpose to use WithAuthPurpose