### PR TITLE
fix(tus): add missing Swagger metadata for OPTIONS route

### DIFF
--- a/tus/tus.go
+++ b/tus/tus.go
@@ -242,6 +242,7 @@ func RegisterTusRoutes(
 		{http.MethodHead, router.TusHeadSwagger, true},
 		{http.MethodPatch, router.TusPatchSwagger, true},
 		{http.MethodDelete, router.TusDeleteSwagger, true},
+		{http.MethodOptions, router.TusOptionsSwagger, true}, // OPTIONS route also needs ID path
 	}
 
 	// Build main routes
@@ -251,25 +252,26 @@ func RegisterTusRoutes(
 		if cfg.hasIDPath {
 			path += idPathSuffix
 		}
-		routes = append(routes, buildRouteOptions(cfg.method, path, cfg.swaggerFunc))
+		
+		route := buildRouteOptions(cfg.method, path, cfg.swaggerFunc)
+		routes = append(routes, route)
 	}
 
-	// Add OPTIONS routes for both base path and ID path
-	for _, path := range []string{basePath, basePath + "/:id"} {
-		routes = append(routes, router.NewRoute(
-			http.MethodOptions,
-			path,
-			dummyOptionsHandler,
-			router.WithSwaggerOptions(func(d *swagger.Definitions, _ string) {
-				*d = router.TusOptionsSwagger(
-					"Get TUS Server Capabilities",
-					"Retrieves information about the TUS server's supported versions, extensions, and limits.",
-					commonErrResp,
-				)
-			}),
-			router.WithMiddlewares(mw...),
-		))
-	}
+	// Add base path OPTIONS route (no ID)
+	optionsBaseRoute := router.NewRoute(
+		http.MethodOptions,
+		basePath,
+		dummyOptionsHandler,
+		router.WithSwaggerOptions(func(d *swagger.Definitions, _ string) {
+			*d = router.TusOptionsSwagger(
+				"Get TUS Server Capabilities",
+				"Retrieves information about the TUS server's supported versions, extensions, and limits.",
+				commonErrResp,
+			)
+		}),
+		router.WithMiddlewares(mw...),
+	)
+	routes = append(routes, optionsBaseRoute)
 
 	routes = router.DefineRoutes(routes...)
 

--- a/tus/tus.go
+++ b/tus/tus.go
@@ -252,7 +252,42 @@ func RegisterTusRoutes(
 	routes = append(routes, deleteRoute)
 
 	// OPTIONS route (with ID) - for CORS preflight on specific uploads
-	optionsRoute := buildRouteOptions(http.MethodOptions, basePath+idPathSuffix, router.TusOptionsSwagger)
+	optionsRoute := buildRouteOptions(http.MethodOptions, basePath+idPathSuffix, func(summary, description string, errors map[int]any) swagger.Definitions {
+		defs := router.TusOptionsSwagger(summary, description, errors)
+		// Ensure the path parameter is properly defined
+		if defs.Paths != nil {
+			for path, pathItem := range defs.Paths {
+				if strings.Contains(path, "{id}") {
+					for method, operation := range pathItem {
+						if method == "options" {
+							if operation.Parameters == nil {
+								operation.Parameters = []swagger.Parameter{}
+							}
+							// Check if 'id' parameter is already defined
+							hasIDParam := false
+							for _, param := range operation.Parameters {
+								if param.Name == "id" && param.In == "path" {
+									hasIDParam = true
+									break
+								}
+							}
+							// Add 'id' path parameter if missing
+							if !hasIDParam {
+								operation.Parameters = append(operation.Parameters, swagger.Parameter{
+									Name:        "id",
+									In:          "path",
+									Description: "Upload ID",
+									Required:    true,
+									Schema:      swagger.Schema{Type: "string"},
+								})
+							}
+						}
+					}
+				}
+			}
+		}
+		return defs
+	})
 	routes = append(routes, optionsRoute)
 
 	// Add base path OPTIONS route (no ID) - for CORS preflight on base path

--- a/tus/tus.go
+++ b/tus/tus.go
@@ -252,7 +252,12 @@ func RegisterTusRoutes(
 	routes = append(routes, deleteRoute)
 
 	// OPTIONS route (with ID) - for CORS preflight on specific uploads
-	optionsRoute := buildRouteOptions(http.MethodOptions, basePath+idPathSuffix, router.TusOptionsSwagger)
+	optionsRoute := buildRouteOptions(http.MethodOptions, basePath+idPathSuffix, func(summary, description string, errResp map[int]any) swagger.Definitions {
+		def := router.TusOptionsSwagger(summary, description, nil, errResp)
+		// Add ID path parameter for this route
+		def = router.SwaggerPathParam(def, "id", "The ID of the upload resource.", "string")
+		return def
+	})
 	routes = append(routes, optionsRoute)
 
 	// Add base path OPTIONS route (no ID) - for CORS preflight on base path
@@ -264,6 +269,7 @@ func RegisterTusRoutes(
 			*d = router.TusOptionsSwagger(
 				"Get TUS Server Capabilities",
 				"Retrieves information about the TUS server's supported versions, extensions, and limits.",
+				nil,
 				commonErrResp,
 			)
 		}),

--- a/tus/tus.go
+++ b/tus/tus.go
@@ -230,36 +230,32 @@ func RegisterTusRoutes(
 		return router.NewRoute(method, path, tusHandler, opts...)
 	}
 
-	// Define route configurations
 	idPathSuffix := "/:id"
 	
-	routeConfigs := []struct {
-		method       string
-		swaggerFunc  func(string, string, map[int]any) swagger.Definitions
-		hasIDPath    bool
-	}{
-		{http.MethodPost, router.TusPostSwagger, false},
-		{http.MethodHead, router.TusHeadSwagger, true},
-		{http.MethodPatch, router.TusPatchSwagger, true},
-		{http.MethodDelete, router.TusDeleteSwagger, true},
-		{http.MethodOptions, func(summary, description string, errors map[int]any) swagger.Definitions {
-			return router.TusOptionsSwagger(summary, description, errors)
-		}, true}, // OPTIONS route also needs ID path
-	}
-
-	// Build main routes
+	// Build main routes explicitly
 	var routes []router.RouteDefinition
-	for _, cfg := range routeConfigs {
-		path := basePath
-		if cfg.hasIDPath {
-			path += idPathSuffix
-		}
-		
-		route := buildRouteOptions(cfg.method, path, cfg.swaggerFunc)
-		routes = append(routes, route)
-	}
+	
+	// POST route (no ID)
+	postRoute := buildRouteOptions(http.MethodPost, basePath, router.TusPostSwagger)
+	routes = append(routes, postRoute)
 
-	// Add base path OPTIONS route (no ID)
+	// HEAD route (with ID)
+	headRoute := buildRouteOptions(http.MethodHead, basePath+idPathSuffix, router.TusHeadSwagger)
+	routes = append(routes, headRoute)
+
+	// PATCH route (with ID)
+	patchRoute := buildRouteOptions(http.MethodPatch, basePath+idPathSuffix, router.TusPatchSwagger)
+	routes = append(routes, patchRoute)
+
+	// DELETE route (with ID)
+	deleteRoute := buildRouteOptions(http.MethodDelete, basePath+idPathSuffix, router.TusDeleteSwagger)
+	routes = append(routes, deleteRoute)
+
+	// OPTIONS route (with ID) - for CORS preflight on specific uploads
+	optionsRoute := buildRouteOptions(http.MethodOptions, basePath+idPathSuffix, router.TusOptionsSwagger)
+	routes = append(routes, optionsRoute)
+
+	// Add base path OPTIONS route (no ID) - for CORS preflight on base path
 	optionsBaseRoute := router.NewRoute(
 		http.MethodOptions,
 		basePath,

--- a/tus/tus.go
+++ b/tus/tus.go
@@ -252,42 +252,7 @@ func RegisterTusRoutes(
 	routes = append(routes, deleteRoute)
 
 	// OPTIONS route (with ID) - for CORS preflight on specific uploads
-	optionsRoute := buildRouteOptions(http.MethodOptions, basePath+idPathSuffix, func(summary, description string, errors map[int]any) swagger.Definitions {
-		defs := router.TusOptionsSwagger(summary, description, errors)
-		// Ensure the path parameter is properly defined
-		if defs.Paths != nil {
-			for path, pathItem := range defs.Paths {
-				if strings.Contains(path, "{id}") {
-					for method, operation := range pathItem {
-						if method == "options" {
-							if operation.Parameters == nil {
-								operation.Parameters = []swagger.Parameter{}
-							}
-							// Check if 'id' parameter is already defined
-							hasIDParam := false
-							for _, param := range operation.Parameters {
-								if param.Name == "id" && param.In == "path" {
-									hasIDParam = true
-									break
-								}
-							}
-							// Add 'id' path parameter if missing
-							if !hasIDParam {
-								operation.Parameters = append(operation.Parameters, swagger.Parameter{
-									Name:        "id",
-									In:          "path",
-									Description: "Upload ID",
-									Required:    true,
-									Schema:      swagger.Schema{Type: "string"},
-								})
-							}
-						}
-					}
-				}
-			}
-		}
-		return defs
-	})
+	optionsRoute := buildRouteOptions(http.MethodOptions, basePath+idPathSuffix, router.TusOptionsSwagger)
 	routes = append(routes, optionsRoute)
 
 	// Add base path OPTIONS route (no ID) - for CORS preflight on base path

--- a/tus/tus.go
+++ b/tus/tus.go
@@ -242,7 +242,9 @@ func RegisterTusRoutes(
 		{http.MethodHead, router.TusHeadSwagger, true},
 		{http.MethodPatch, router.TusPatchSwagger, true},
 		{http.MethodDelete, router.TusDeleteSwagger, true},
-		{http.MethodOptions, router.TusOptionsSwagger, true}, // OPTIONS route also needs ID path
+		{http.MethodOptions, func(summary, description string, errors map[int]any) swagger.Definitions {
+			return router.TusOptionsSwagger(summary, description, errors)
+		}, true}, // OPTIONS route also needs ID path
 	}
 
 	// Build main routes


### PR DESCRIPTION
- Explicitly configure OPTIONS route with proper swagger documentation
- Ensure TusOptionsSwagger is called with correct endpoint description
- Maintain consistent swagger metadata across all TUS protocol methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OPTIONS is now available only at the base TUS endpoint, no longer exposed on ID-based paths.
  * Prevents unintended OPTIONS responses on resource-specific routes.

* **Documentation**
  * Enhanced API documentation for the OPTIONS endpoint to describe TUS server capabilities.
  * Added common error responses for the OPTIONS request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->