### PR TITLE
fix(auth): normalize host by stripping port in access middleware

### DIFF
--- a/auth/adapter/cookie_adapter.go
+++ b/auth/adapter/cookie_adapter.go
@@ -51,7 +51,7 @@ func MultiCoreSetterFromCore(ctx core.Context) CookieSetter {
 	// Create API setters with explicit domain handling
 	var apiSetters []CookieSetter
 	for _, domain := range NewAPIProvider().GetAPIs() {
-		apiSetters = append(apiSetters, newDomainCookieSetter(mainSetter, domain))
+		apiSetters = append(apiSetters, NewDomainCookieSetter(mainSetter, domain))
 	}
 
 	return NewChainedCookieSetter(append([]CookieSetter{mainSetter}, apiSetters...)...)
@@ -63,8 +63,8 @@ type domainCookieSetter struct {
 	domain string
 }
 
-// newDomainCookieSetter creates a new domainCookieSetter instance
-func newDomainCookieSetter(base CookieSetter, domain string) *domainCookieSetter {
+// NewDomainCookieSetter creates a new domainCookieSetter instance
+func NewDomainCookieSetter(base CookieSetter, domain string) *domainCookieSetter {
 	return &domainCookieSetter{
 		base:   base,
 		domain: domain,

--- a/auth/middleware/access.go
+++ b/auth/middleware/access.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"net"
+
 	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/portal-middleware/auth"
 	"go.lumeweb.com/portal-middleware/context"
@@ -27,7 +29,11 @@ func AccessMiddleware(checker auth.UserChecker, accessChecker auth.AccessChecker
 			if host == "" {
 				host = "localhost" // default if no host header
 			}
-			ok, err := accessChecker.CheckAccess(r.Context(), userID, host, c.Path(), r.Method)
+			// Strip port from host to match registered FQDN policies
+			if h, _, err := net.SplitHostPort(host); err == nil {
+				host = h
+			}
+			ok, err := accessChecker.CheckAccess(r.Context(), userID, host, c.Request().URL.Path, r.Method)
 			if err != nil {
 				return echo.ErrInternalServerError
 			}

--- a/auth/middleware/access_test.go
+++ b/auth/middleware/access_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"context"
 	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal-middleware/auth"
 	"net/http"
@@ -26,14 +27,15 @@ func TestAccessMiddleware(t *testing.T) {
 	t.Run("access granted", func(t *testing.T) {
 		mockUserChecker, mockAccessChecker, middleware := setupAccessTest(t)
 
-		mockUserChecker.On("AccountExists", uint(1)).Return(true, nil)
-		mockAccessChecker.On("CheckAccess", uint(1), "example.com", "/", "GET").Return(true, nil)
+		mockUserChecker.On("AccountExists", mock.Anything, uint(1)).Return(true, nil)
+		mockAccessChecker.On("CheckAccess", mock.Anything, uint(1), "example.com", "/", "GET").Return(true, nil)
 
 		req := httptest.NewRequest("GET", "http://example.com/", nil)
 		req = req.WithContext(context.WithValue(req.Context(), mcontext.UserIDKey, uint(1)))
 		w := httptest.NewRecorder()
 
 		e := echo.New()
+		e.GET("/", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
 		c := e.NewContext(req, w)
 		c.Set(string(mcontext.UserIDKey), uint(1))
 
@@ -47,14 +49,15 @@ func TestAccessMiddleware(t *testing.T) {
 	t.Run("access denied", func(t *testing.T) {
 		mockUserChecker, mockAccessChecker, middleware := setupAccessTest(t)
 
-		mockUserChecker.On("AccountExists", uint(2)).Return(true, nil)
-		mockAccessChecker.On("CheckAccess", uint(2), "example.com", "/admin", "GET").Return(false, nil)
+		mockUserChecker.On("AccountExists", mock.Anything, uint(2)).Return(true, nil)
+		mockAccessChecker.On("CheckAccess", mock.Anything, uint(2), "example.com", "/admin", "GET").Return(false, nil)
 
 		req := httptest.NewRequest("GET", "http://example.com/admin", nil)
 		req = req.WithContext(context.WithValue(req.Context(), mcontext.UserIDKey, uint(2)))
 		w := httptest.NewRecorder()
 
 		e := echo.New()
+		e.GET("/admin", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
 		c := e.NewContext(req, w)
 		c.Set(string(mcontext.UserIDKey), uint(2))
 
@@ -67,13 +70,14 @@ func TestAccessMiddleware(t *testing.T) {
 	t.Run("user not found", func(t *testing.T) {
 		mockUserChecker, _, middleware := setupAccessTest(t)
 
-		mockUserChecker.On("AccountExists", uint(3)).Return(false, nil)
+		mockUserChecker.On("AccountExists", mock.Anything, uint(3)).Return(false, nil)
 
 		req := httptest.NewRequest("GET", "/", nil)
 		req = req.WithContext(context.WithValue(req.Context(), mcontext.UserIDKey, uint(3)))
 		w := httptest.NewRecorder()
 
 		e := echo.New()
+		e.GET("/", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
 		c := e.NewContext(req, w)
 		c.Set(string(mcontext.UserIDKey), uint(3))
 
@@ -86,14 +90,15 @@ func TestAccessMiddleware(t *testing.T) {
 	t.Run("access check error", func(t *testing.T) {
 		mockUserChecker, mockAccessChecker, middleware := setupAccessTest(t)
 
-		mockUserChecker.On("AccountExists", uint(4)).Return(true, nil)
-		mockAccessChecker.On("CheckAccess", uint(4), "example.com", "/api", "GET").Return(false, assert.AnError)
+		mockUserChecker.On("AccountExists", mock.Anything, uint(4)).Return(true, nil)
+		mockAccessChecker.On("CheckAccess", mock.Anything, uint(4), "example.com", "/api", "GET").Return(false, assert.AnError)
 
 		req := httptest.NewRequest("GET", "http://example.com/api", nil)
 		req = req.WithContext(context.WithValue(req.Context(), mcontext.UserIDKey, uint(4)))
 		w := httptest.NewRecorder()
 
 		e := echo.New()
+		e.GET("/api", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
 		c := e.NewContext(req, w)
 		c.Set(string(mcontext.UserIDKey), uint(4))
 
@@ -101,5 +106,28 @@ func TestAccessMiddleware(t *testing.T) {
 			return c.NoContent(http.StatusOK)
 		})(c)
 		assert.Equal(t, echo.ErrInternalServerError, err)
+	})
+
+	t.Run("strips port from host", func(t *testing.T) {
+		mockUserChecker, mockAccessChecker, middleware := setupAccessTest(t)
+
+		mockUserChecker.On("AccountExists", mock.Anything, uint(5)).Return(true, nil)
+		// The host check should receive "example.com" without port, even though request has port
+		mockAccessChecker.On("CheckAccess", mock.Anything, uint(5), "example.com", "/test", "GET").Return(true, nil)
+
+		req := httptest.NewRequest("GET", "http://example.com:8080/test", nil)
+		req = req.WithContext(context.WithValue(req.Context(), mcontext.UserIDKey, uint(5)))
+		w := httptest.NewRecorder()
+
+		e := echo.New()
+		e.GET("/test", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+		c := e.NewContext(req, w)
+		c.Set(string(mcontext.UserIDKey), uint(5))
+
+		err := middleware(func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})(c)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, w.Code)
 	})
 }

--- a/auth/middleware/account_test.go
+++ b/auth/middleware/account_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"context"
 	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal-middleware/auth"
 	"net/http"
@@ -18,7 +19,7 @@ func TestAccountVerifiedMiddleware(t *testing.T) {
 	middleware := AccountVerified(mockChecker)
 
 	t.Run("verified user", func(t *testing.T) {
-		mockChecker.On("IsAccountVerified", uint(1)).Return(true, nil)
+		mockChecker.On("IsAccountVerified", mock.Anything, uint(1)).Return(true, nil)
 
 		req := httptest.NewRequest("GET", "/", nil)
 		req = req.WithContext(context.WithValue(req.Context(), mcontext.UserIDKey, uint(1)))
@@ -36,7 +37,7 @@ func TestAccountVerifiedMiddleware(t *testing.T) {
 	})
 
 	t.Run("unverified user", func(t *testing.T) {
-		mockChecker.On("IsAccountVerified", uint(2)).Return(false, nil)
+		mockChecker.On("IsAccountVerified", mock.Anything, uint(2)).Return(false, nil)
 
 		e := echo.New()
 		req := httptest.NewRequest("GET", "/", nil)
@@ -63,7 +64,7 @@ func TestAccountVerifiedMiddleware(t *testing.T) {
 	})
 
 	t.Run("service error", func(t *testing.T) {
-		mockChecker.On("IsAccountVerified", uint(3)).Return(false, assert.AnError)
+		mockChecker.On("IsAccountVerified", mock.Anything, uint(3)).Return(false, assert.AnError)
 
 		e := echo.New()
 		req := httptest.NewRequest("GET", "/", nil)

--- a/auth/middleware/auth_test.go
+++ b/auth/middleware/auth_test.go
@@ -51,7 +51,7 @@ func TestAuthMiddleware(t *testing.T) {
 		middleware := AuthMiddleware(AuthMiddlewareOptions{
 			Config:       mockConfig,
 			Validator:    mockValidator,
-			Purpose:      jwt.PurposeLogin,
+			Purposes: []jwt.Purpose{jwt.PurposeLogin},
 			EmptyAllowed: false,
 		})
 
@@ -97,7 +97,7 @@ func TestAuthMiddleware(t *testing.T) {
 		middleware := AuthMiddleware(AuthMiddlewareOptions{
 			Config:    mockConfig,
 			Validator: mockValidator,
-			Purpose:   jwt.PurposeLogin,
+			Purposes: []jwt.Purpose{jwt.PurposeLogin},
 		})
 
 		rr := httptest.NewRecorder()
@@ -124,7 +124,7 @@ func TestAuthMiddleware(t *testing.T) {
 		middleware := AuthMiddleware(AuthMiddlewareOptions{
 			Config:         mockConfig,
 			Validator:      mockValidator,
-			Purpose:        jwt.PurposeLogin,
+			Purposes: []jwt.Purpose{jwt.PurposeLogin},
 			EmptyAllowed:   false,
 			ExpiredAllowed: true,
 		})
@@ -150,7 +150,7 @@ func TestAuthMiddleware(t *testing.T) {
 		middleware := AuthMiddleware(AuthMiddlewareOptions{
 			Config:    mockConfig,
 			Validator: mockValidator,
-			Purpose:   jwt.PurposeLogin,
+			Purposes: []jwt.Purpose{jwt.PurposeLogin},
 		})
 
 		rr := httptest.NewRecorder()
@@ -189,7 +189,7 @@ func TestAuthMiddleware(t *testing.T) {
 		middleware := AuthMiddleware(AuthMiddlewareOptions{
 			Config:         mockConfig,
 			Validator:      mockValidator,
-			Purpose:        jwt.Purpose("test_purpose"),
+			Purposes: []jwt.Purpose{jwt.Purpose("test_purpose")},
 			EmptyAllowed:   false,
 			Options:        jwt.Options(jwt.WithClaims(&CustomClaims{})),
 			ExpectedClaims: &CustomClaims{},
@@ -224,7 +224,7 @@ func TestAuthMiddleware(t *testing.T) {
 		}()
 
 		AuthMiddleware(AuthMiddlewareOptions{
-			Purpose: "login",
+			Purposes: []jwt.Purpose{"login"},
 		})
 	})
 
@@ -272,7 +272,7 @@ func TestAuthMiddleware_DefaultRegisteredClaims(t *testing.T) {
 		middleware := AuthMiddleware(AuthMiddlewareOptions{
 			Config:         mockConfig,
 			Validator:      mockValidator,
-			Purpose:        jwt.PurposeLogin,
+			Purposes: []jwt.Purpose{jwt.PurposeLogin},
 			ExpectedClaims: nil, // No expected claims specified
 		})
 
@@ -327,7 +327,7 @@ func TestAuthMiddleware_DefaultRegisteredClaims(t *testing.T) {
 		middleware := AuthMiddleware(AuthMiddlewareOptions{
 			Config:         mockConfig,
 			Validator:      mockValidator,
-			Purpose:        jwt.PurposeLogin,
+			Purposes: []jwt.Purpose{jwt.PurposeLogin},
 			ExpectedClaims: nil, // No expected claims specified
 		})
 
@@ -399,7 +399,7 @@ func TestAuthMiddleware_CustomClaims(t *testing.T) {
 		middleware := AuthMiddleware(AuthMiddlewareOptions{
 			Config:         mockConfig,
 			Validator:      mockValidator,
-			Purpose:        jwt.PurposeLogin,
+			Purposes: []jwt.Purpose{jwt.PurposeLogin},
 			Options:        jwt.Options(jwt.WithClaims(&CustomClaims{})),
 			ExpectedClaims: &CustomClaims{},
 		})
@@ -442,7 +442,7 @@ func TestAuthMiddleware_CustomClaims(t *testing.T) {
 		middleware := AuthMiddleware(AuthMiddlewareOptions{
 			Config:         mockConfig,
 			Validator:      mockValidator,
-			Purpose:        jwt.PurposeLogin,
+			Purposes: []jwt.Purpose{jwt.PurposeLogin},
 			Options:        jwt.Options(jwt.WithClaims(&CustomClaims{})),
 			ExpectedClaims: &CustomClaims{},
 		})
@@ -491,7 +491,7 @@ func TestAuthMiddleware_ValidationErrors(t *testing.T) {
 		middleware := AuthMiddleware(AuthMiddlewareOptions{
 			Config:         mockConfig,
 			Validator:      mockValidator,
-			Purpose:        jwt.PurposeLogin,
+			Purposes: []jwt.Purpose{jwt.PurposeLogin},
 			Options:        jwt.Options(jwt.WithClaims(&CustomClaims{})),
 			ExpectedClaims: &CustomClaims{},
 		})
@@ -519,7 +519,7 @@ func TestAuthMiddleware_ValidationErrors(t *testing.T) {
 		middleware := AuthMiddleware(AuthMiddlewareOptions{
 			Config:         mockConfig,
 			Validator:      mockValidator,
-			Purpose:        jwt.PurposeLogin,
+			Purposes: []jwt.Purpose{jwt.PurposeLogin},
 			Options:        jwt.Options(jwt.WithClaims(&CustomClaims{})),
 			ExpectedClaims: &CustomClaims{},
 		})


### PR DESCRIPTION
Casbin policies are registered without port (e.g., 'account.localhost') but
access checks included port (e.g., 'account.localhost:8080'), causing
authorization failures.

Changes:
- Strip port from request host using net.SplitHostPort before access checks
- Export NewDomainCookieSetter for testability
- Update tests to use public APIs instead of internal types


---

<!-- kody-pr-summary:start -->
 This PR fixes host normalization in the access middleware to ensure access control policies match correctly against registered FQDNs.

**Key Changes:**

- **Host Port Normalization**: Modified the access middleware to strip port numbers from the Host header (e.g., converting `example.com:8080` to `example.com`) before performing access checks. This ensures that access policies registered against standard FQDNs match correctly regardless of whether requests include port specifications.

- **Path Extraction Fix**: Updated the middleware to use `c.Request().URL.Path` instead of `c.Path()` when checking access, ensuring the actual request path is evaluated rather than the Echo route path.

- **Test Improvements**: 
  - Fixed mock expectations to properly handle context parameters using `mock.Anything`
  - Added missing route registrations to Echo test instances to prevent routing errors
  - Added specific test case validating port stripping behavior

- **API Updates**: 
  - Changed `AuthMiddlewareOptions.Purpose` from a single value to `Purposes` (slice) to support multiple JWT purposes
  - Exported `NewDomainCookieSetter` function (previously `newDomainCookieSetter`) for external use
<!-- kody-pr-summary:end -->