### PR TITLE
fix(tus): add missing id path parameter to OPTIONS route with ID

### DIFF
--- a/tus/tus.go
+++ b/tus/tus.go
@@ -250,10 +250,15 @@ func RegisterTusRoutes(
 		basePath+idPathSuffix,
 		tusHandler,
 		router.WithSwaggerOptions(func(d *swagger.Definitions, _ string) {
-			*d = router.TusOptionsSwagger(
-				"Get TUS Upload Capabilities",
-				"Retrieves information about the TUS server's supported versions, extensions, and limits.",
-				commonErrResp,
+			*d = router.SwaggerPathParam(
+				router.TusOptionsSwagger(
+					"Get TUS Upload Capabilities",
+					"Retrieves information about the TUS server's supported versions, extensions, and limits.",
+					commonErrResp,
+				),
+				"id",
+				"The ID of the upload resource.",
+				"string",
 			)
 		}),
 		router.WithMiddlewares(mw...),


### PR DESCRIPTION
The OPTIONS route with ID path ({id}) was missing the swagger path parameter
definition, causing OpenAPI validation to fail on startup.

Added router.SwaggerPathParam to properly define the 'id' parameter for the
OPTIONS route to specific upload IDs.


---

<!-- kody-pr-summary:start -->
 This pull request fixes the Swagger/OpenAPI documentation for the TUS protocol OPTIONS endpoint that handles specific upload resources.

**Changes Made:**
- Added the missing `id` path parameter definition to the OPTIONS route documentation at the path suffix that includes an upload ID
- Wrapped the existing `TusOptionsSwagger` definition with `SwaggerPathParam` to properly declare the `id` parameter as a required string path parameter with the description "The ID of the upload resource"

**Functional Impact:**
The API documentation now accurately reflects that the OPTIONS endpoint for specific upload resources requires an `id` path parameter. This ensures proper client generation and API discovery tools correctly identify the route parameter when interacting with the TUS upload capabilities endpoint.
<!-- kody-pr-summary:end -->